### PR TITLE
Add a pyproject.toml exposing this as a Kalico plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "tmc4671"
+version = "0.1.0"
+description = "Kalico plugin for TMC-4671 drivers"
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = []
+
+[project.entry-points."kalico.plugins"]
+tmc4671 = "tmc4671"


### PR DESCRIPTION
This builds a package with the entrypoint `kalico.plugins.tmc4671`, which can be loaded by https://github.com/KalicoCrew/kalico/pull/705