### PR TITLE
Add TMC_DEBUG_TUNING command, G-code reference docs, and AGENTS conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,4 @@ tmc-4671/
 - **Datasheet Revision**: The correct version of the TMC 4671 datasheet to use is **version 2.08**. Do not use older or newer versions unless explicitly instructed, as register addresses or features can vary.
 - **Firmware Context**: This repository is a plugin for the **Kalico** 3d printer firmware (and is structured to integrate with Kalico/Klipper).
 - **Refactoring**: When extracting code into new files, ensure this file is updated.
+- **Commit style**: Plain English, no conventional-commit prefixes (e.g. "Add motor inductance measurement", not "feat: add motor inductance measurement").

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,4 @@ tmc-4671/
 - **Refactoring**: When extracting code into new files, ensure this file is updated.
 - **Installer**: `install.sh` symlinks each Python module file into Klipper's `extras/` directory. When adding a new module file, add a corresponding `ln -srfn` line to `link_extension` in `install.sh` and run the script (or create the symlink manually) on the target machine, otherwise Klipper will fail to import the module.
 - **Commit style**: Plain English, no conventional-commit prefixes (e.g. "Add motor inductance measurement", not "feat: add motor inductance measurement").
+- **G-code commands**: When adding or changing a G-code command, update the "G-code command reference" section at the end of `README.md` to reflect the new or changed command, its parameters, and their defaults.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,17 +8,21 @@
 ## STRUCTURE
 ```text
 tmc-4671/
-├── __init__.py      # Plugin entry point for Kalico
-├── tmc4671.py       # Core driver implementation (SPI registers, PID tuning, calibration, biquad filters)
-├── pyproject.toml   # Project configuration defining the "kalico.plugins" entry-point
-└── README.md        # Hardware setup, wiring, moonraker configuration, and PID tuning instructions
+├── __init__.py         # Plugin entry point for Kalico
+├── tmc4671_regs.py     # SPI registers
+├── tmc4671_biquad.py   # Biquad filter design utilities (BiquadFilter, design functions, TMC normalisation)
+├── tmc4671.py          # Core driver implementation (PID tuning, calibration, SPI, G-code commands)
+├── pyproject.toml      # Project configuration defining the "kalico.plugins" entry-point
+└── README.md           # Hardware setup, wiring, moonraker configuration, and PID tuning instructions
 ```
 
 ## WHERE TO LOOK
 - **Chip Datasheet**: [TMC 4671 LA Datasheet version 2.08](datasheet/TMC4671-LA_datasheet_rev2.08.noimages.md).
-- **Register Map & SPI Communication**: Located in [tmc4671_regs.py](tmc4671_regs.py). This file defines register addresses, sub-registers.
+- **Register Map**: Located in [tmc4671_regs.py](tmc4671_regs.py). This file defines register addresses, sub-registers.
+- **Biquad filter design**: Located in [tmc4671_biquad.py](tmc4671_biquad.py). Contains `BiquadFilter`, filter type/target constants, and all `biquad_*` design/normalisation functions.
 - **Everything else**: Implemented in [tmc4671.py](tmc4671.py).
 
 ## CONVENTIONS & CRITICAL INSTRUCTIONS
 - **Datasheet Revision**: The correct version of the TMC 4671 datasheet to use is **version 2.08**. Do not use older or newer versions unless explicitly instructed, as register addresses or features can vary.
 - **Firmware Context**: This repository is a plugin for the **Kalico** 3d printer firmware (and is structured to integrate with Kalico/Klipper).
+- **Refactoring**: When extracting code into new files, ensure this file is updated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,5 @@ tmc-4671/
 - **Datasheet Revision**: The correct version of the TMC 4671 datasheet to use is **version 2.08**. Do not use older or newer versions unless explicitly instructed, as register addresses or features can vary.
 - **Firmware Context**: This repository is a plugin for the **Kalico** 3d printer firmware (and is structured to integrate with Kalico/Klipper).
 - **Refactoring**: When extracting code into new files, ensure this file is updated.
+- **Installer**: `install.sh` symlinks each Python module file into Klipper's `extras/` directory. When adding a new module file, add a corresponding `ln -srfn` line to `link_extension` in `install.sh` and run the script (or create the symlink manually) on the target machine, otherwise Klipper will fail to import the module.
 - **Commit style**: Plain English, no conventional-commit prefixes (e.g. "Add motor inductance measurement", not "feat: add motor inductance measurement").

--- a/README.md
+++ b/README.md
@@ -158,3 +158,166 @@ TMC_TUNE_MOTION_PID LAMBDA_V=80 LAMBDA_P=180 KT=0.022 STEPPER=stepper_y
 depending on whether you know a KT value (in nM/A) or holding specifications. Lambda_v and Lambda_p are measures of how aggressive the tuning will be. Lambda_v can go from approximately 45 up, and Lambda_p should be at least twice Lambda_v; the default values are Lambda_v=100 and Lambda_p=400. `SAVE_CONFIG` will save the tuning values. The command will also suggest filter frequencies, but will not apply them.
 
 If the motors make noise at rest after autotuning, increase the Lambda values. If not, consider decreasing them; the minimum value that remains quiet at rest is likely also the optimal value.
+
+## G-code command reference
+
+All commands take `STEPPER=<name>` to select the driver, e.g. `STEPPER=stepper_x`.
+
+### INIT_TMC
+
+Re-initialises all TMC 4671 registers from the config and runs ADC offset calibration. Useful after a power glitch without a full Klipper restart.
+
+```
+INIT_TMC STEPPER=stepper_x
+```
+
+### SET_TMC_CURRENT
+
+Get or set the run current limit.
+
+```
+SET_TMC_CURRENT STEPPER=stepper_x [CURRENT=<amps>]
+```
+
+Without `CURRENT`, reports the currently active limit. With `CURRENT`, updates the `PID_TORQUE_FLUX_LIMITS` register immediately.
+
+### TMC_TUNE_PID
+
+Autotune flux and torque PID coefficients and queue the results for `SAVE_CONFIG`.
+
+```
+TMC_TUNE_PID STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [SIMC=<0|1>] [CHECK=<0|1>] [DERATE=<factor>]
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `CURRENT_BANDWIDTH` | 1800.0 | Target closed-loop current bandwidth in Hz. Higher values are faster but noisier. |
+| `SIMC` | 0 | Use S-IMC setpoint-change experiment instead of the bandwidth method. |
+| `CHECK` | 0 | With `SIMC=1`: test the *existing* gains instead of starting from scratch. |
+| `DERATE` | 1.6 | With `SIMC=1`: initial gain derate factor. |
+
+The default (bandwidth) method derives P and I analytically from the measured motor R and L. The `SIMC` method runs a live setpoint-change experiment and fits a first-order-plus-dead-time model — more accurate but takes longer and requires the motor to be active.
+
+Output example: `PID stepper_x parameters: Kc=9.66 Ki=0.485`
+
+### TMC_TUNE_MOTION_PID
+
+Autotune velocity and position PID coefficients using S-IMC and queue the results for `SAVE_CONFIG`.
+
+```
+TMC_TUNE_MOTION_PID STEPPER=stepper_x KT=<nm/a> [LAMBDA_V=<val>] [LAMBDA_P=<val>]
+TMC_TUNE_MOTION_PID STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [LAMBDA_V=<val>] [LAMBDA_P=<val>]
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `KT` | — | Motor torque constant in Nm/A. |
+| `HOLDING_CURRENT` | — | Rated holding current in A (alternative to `KT`). |
+| `HOLDING_TORQUE` | — | Rated holding torque in Nm (alternative to `KT`). |
+| `LAMBDA_V` | 100.0 | Velocity loop closed-loop time constant (smaller = faster/noisier). |
+| `LAMBDA_P` | 400.0 | Position loop closed-loop time constant. Should be at least 2× `LAMBDA_V`. |
+
+The command also suggests biquad filter frequencies but does not apply them.
+
+### TMC_DEBUG_TUNING
+
+Report what the PID tuning helpers would compute given the current motor parameters, without writing anything to the controller. Compares computed values against the currently active register values.
+
+```
+TMC_DEBUG_TUNING STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [LAMBDA_V=<val>] [LAMBDA_P=<val>] [KT=<nm/a>]
+TMC_DEBUG_TUNING STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [...]
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `CURRENT_BANDWIDTH` | 1800.0 | Bandwidth in Hz for the current PID calculation. |
+| `LAMBDA_V` | 100.0 | Velocity loop time constant for the motion PID calculation. |
+| `LAMBDA_P` | 400.0 | Position loop time constant for the motion PID calculation. |
+| `KT` | — | Motor torque constant in Nm/A (required for motion PID section). |
+| `HOLDING_CURRENT` + `HOLDING_TORQUE` | — | Alternative way to supply Kt. |
+
+If motor R and L have not yet been measured (startup alignment pending), the current PID section reports that instead of computing. The motion PID section is skipped if no torque constant is provided.
+
+### SET_TMC_BIQUAD_FILTER
+
+Configure a biquad filter on the fly.
+
+```
+SET_TMC_BIQUAD_FILTER STEPPER=stepper_x FILTER=<target> [FREQUENCY=<hz>] [TYPE=<type>] [SLOPE=<q>]
+```
+
+| Parameter | Values | Description |
+|---|---|---|
+| `FILTER` | `flux`, `torque`, `velocity`, `position` | Which signal path to filter. |
+| `FREQUENCY` | 0 – 100000000 | Cutoff frequency in Hz. 0 disables the filter. |
+| `TYPE` | `lpf`, `notch`, `apf` | Filter topology. Default: `lpf`. |
+| `SLOPE` | any positive float | Q factor / slope. Default: 0.707 (Butterworth). |
+
+### SET_TMC_FIELD
+
+Read or write any TMC 4671 register field by name.
+
+```
+SET_TMC_FIELD STEPPER=stepper_x FIELD=<name> [VALUE=<int>|FVAL=<float>]
+```
+
+Without `VALUE` or `FVAL`, reads and prints the current value of the field. `FVAL` uses the field's configured floating-point converter (e.g. for PID coefficients).
+
+### DUMP_TMC
+
+Read and display TMC 4671 registers.
+
+```
+DUMP_TMC STEPPER=stepper_x [GROUP=<name>|REGISTER=<name>|FIELD=<name>]
+```
+
+Available groups: `default`, `hall`, `abn`, `adc`, `aenc`, `pwm`, `pidconf`, `pid`, `step`, `filters`. Without arguments, dumps the `default` group.
+
+### DUMP_TMC6100
+
+Read and display TMC6100 gate driver registers. Only available when `drv_cs_pin` is configured.
+
+```
+DUMP_TMC6100 STEPPER=stepper_x [GROUP=<name>|REGISTER=<name>|FIELD=<name>]
+```
+
+### TMC_DEBUG_VOLTAGE
+
+Report the motor supply voltage (VM) and the FOC d/q axis voltages in both raw counts and volts.
+
+```
+TMC_DEBUG_VOLTAGE STEPPER=stepper_x
+```
+
+### TMC_DEBUG_CURRENT
+
+Report phase currents, FOC target and actual d/q axis currents, and the active current limit.
+
+```
+TMC_DEBUG_CURRENT STEPPER=stepper_x
+```
+
+### TMC_DEBUG_MOTOR
+
+Report the motor resistance and inductance measured during the last startup alignment.
+
+```
+TMC_DEBUG_MOTOR STEPPER=stepper_x
+```
+
+Values are populated after the first successful `klippy:ready` alignment sequence. If the driver has not yet aligned, the command says so.
+
+### TMC_DEBUG_MOVE
+
+Run a raw motion test in a chosen mode. The motor must be free to move. Results are logged to the Klipper log.
+
+```
+TMC_DEBUG_MOVE STEPPER=stepper_x <VELOCITY=<int>|TORQUE=<int>|POSITION=<int>|OPENVEL=<int>>
+```
+
+| Parameter | Description |
+|---|---|
+| `VELOCITY` | Target in velocity-mode raw units. |
+| `TORQUE` | Target in torque-mode raw units. |
+| `POSITION` | Target in position-mode raw units. |
+| `OPENVEL` | Open-loop velocity in raw units (no position feedback). |

--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,7 @@ function link_extension {
 
     ln -srfn "${TMC4671_PATH}/tmc4671.py" "${KLIPPER_PLUGINS_PATH}/tmc4671.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_regs.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_regs.py"
+    ln -srfn "${TMC4671_PATH}/tmc4671_biquad.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_biquad.py"
 }
 
 function restart_klipper {

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1092,6 +1092,26 @@ class TMC4671:
     def _tune_torque_pid(self, test_existing, derate, print_time):
         return self._tune_pid("TORQUE", 1.0, derate, test_existing, print_time)
 
+    def _tune_current_pid(self, current_bandwidth):
+        # 1. Calculate continuous physical gains
+        omega_bw = 2.0 * math.pi * current_bandwidth
+        Kp_physical = omega_bw * self.motor_l
+
+        # 2. Extract hardware loop scaling factors
+        # current_scale is in mA/LSB, convert to A/LSB
+        amps_per_adc_count = self.current_helper.current_scale * 1e-3
+        vm_voltage = self._read_vm()
+
+        hardware_loop_gain = (amps_per_adc_count * 32768.0) / max(vm_voltage, 0.001)
+
+        # 3. Apply loop gain to P
+        P = Kp_physical * hardware_loop_gain
+
+        # 4. Calculate I as an analytical plant ratio for Advanced Mode (Serial structure)
+        # I = R / (L * f_pwm)
+        I = self.motor_r / (self.motor_l * self.pwmfreq)
+        return P, I
+
     # Align motor and measure resistance and inductance on startup
     def _align_and_measure(self, offsets, print_time):
         dwell = self.printer.lookup_object('toolhead').dwell
@@ -1502,39 +1522,21 @@ class TMC4671:
         with self.mutex:
             if simc_flag:
                 P, I = self._tune_flux_pid(test_existing, derate, print_time)
-                self._write_field("PID_TORQUE_P", self.pid_helpers["TORQUE_P"].to_f(P))
-                self._write_field("PID_TORQUE_I", self.pid_helpers["TORQUE_I"].to_f(I))
             else:
-                # 1. Calculate continuous physical gains
-                omega_bw = 2.0 * math.pi * current_bandwidth
-                Kp_physical = omega_bw * self.motor_l
+                P, I = self._tune_current_pid(current_bandwidth)
+            self._write_field("PID_FLUX_P", self.pid_helpers["FLUX_P"].to_f(P))
 
-                # 2. Extract hardware loop scaling factors
-                # current_scale is in mA/LSB, convert to A/LSB
-                amps_per_adc_count = self.current_helper.current_scale * 1e-3
-                vm_voltage = self._read_vm()
+            self._write_field("PID_FLUX_I", self.pid_helpers["FLUX_I"].to_f(I))
+            self._write_field("PID_TORQUE_P", self.pid_helpers["TORQUE_P"].to_f(P))
+            self._write_field("PID_TORQUE_I", self.pid_helpers["TORQUE_I"].to_f(I))
 
-                hardware_loop_gain = (amps_per_adc_count * 32768.0) / max(vm_voltage, 0.001)
-
-                # 3. Apply loop gain to P
-                P = Kp_physical * hardware_loop_gain
-
-                # 4. Calculate I as an analytical plant ratio for Advanced Mode (Serial structure)
-                # I = R / (L * f_pwm)
-                I = self.motor_r / (self.motor_l * self.pwmfreq)
-                self._write_field("PID_FLUX_P", self.pid_helpers["FLUX_P"].to_f(P))
-
-                self._write_field("PID_FLUX_I", self.pid_helpers["FLUX_I"].to_f(I))
-                self._write_field("PID_TORQUE_P", self.pid_helpers["TORQUE_P"].to_f(P))
-                self._write_field("PID_TORQUE_I", self.pid_helpers["TORQUE_I"].to_f(I))
-
-                # Store results for SAVE_CONFIG
-                cfgname = "tmc4671 %s" % (self.name,)
-                configfile = self.printer.lookup_object('configfile')
-                configfile.set(cfgname, 'foc_PID_FLUX_P', "%.3f" % (P,))
-                configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (I,))
-                configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (P,))
-                configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (I,))
+            # Store results for SAVE_CONFIG
+            cfgname = "tmc4671 %s" % (self.name,)
+            configfile = self.printer.lookup_object('configfile')
+            configfile.set(cfgname, 'foc_PID_FLUX_P', "%.3f" % (P,))
+            configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (I,))
+            configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (P,))
+            configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (I,))
         gcmd.respond_info(
             "PID %s parameters: Kc=%.2f Ki=%.3f\n"
             "The SAVE_CONFIG command will update the printer config file\n"

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -11,7 +11,6 @@ import logging, collections
 import math
 from time import monotonic_ns
 from enum import IntEnum
-from typing import NamedTuple
 from statistics import median_low, mean, fmean
 from extras import bus, tmc, thermistor
 from .tmc4671_regs import (
@@ -19,6 +18,11 @@ from .tmc4671_regs import (
     ADC_GPIO_FIELDS, Fields, FloatFields, SignedFields,
     FieldFormatters, to_q4_12, from_q4_12, to_q8_8, from_q8_8,
     to_q2_30, from_q2_30
+)
+from .tmc4671_biquad import (
+    BiquadFilter, BIQUAD_FILTER_TYPES, BIQUAD_FILTER_TARGETS,
+    biquad_lpf_tmc, biquad_lpf, biquad_notch, biquad_apf,
+    biquad_Z_tmc, biquad_tmc
 )
 
 # The 4671 has a 25 MHz external clock
@@ -33,11 +37,6 @@ class MotionMode(IntEnum):
     velocity_mode = 2
     position_mode = 3
     uq_ud_ext_mode = 8
-
-class BiquadFilter(NamedTuple):
-    type: str
-    freq: int
-    slope: float
 
 # Tuple is the address followed by a value to put in the next higher address
 # to select that sub-register, or none to just go straight there.
@@ -113,98 +112,9 @@ DumpGroups = {
                 "CONFIG_BIQUAD_F_B_2", "CONFIG_BIQUAD_F_ENABLE",],
 }
 
-
 ######################################################################
-# Biquad filter utilities
+# PI controller utilities
 ######################################################################
-
-BIQUAD_FILTER_TYPES = ['lpf', 'notch', 'apf']
-BIQUAD_FILTER_TARGETS = {
-        'flux': 'CONFIG_BIQUAD_F_ENABLE',
-        'torque': 'CONFIG_BIQUAD_T_ENABLE',
-        'velocity': 'CONFIG_BIQUAD_V_ENABLE',
-        'position': 'CONFIG_BIQUAD_X_ENABLE',
-}
-
-# Filter design formula from 4671 datasheet
-def biquad_lpf_tmc(fs, f, D):
-    w0 = 2.0 * math.pi * f / fs
-    b2 = b1 = 0.0
-    b0 = 1.0
-    a2 = 1.0 / (w0**2)
-    a1 = 2.0 * D / w0
-    a0 = 1.0
-    return b0, b1, b2, a0, a1, a2
-
-# Filter design formulae from https://www.w3.org/TR/audio-eq-cookbook/
-
-# Design a biquad low pass filter in canonical form
-def biquad_lpf(fs, f, Q):
-    w0 = 2.0 * math.pi * f / fs
-    cw0 = math.cos(w0)
-    sw0 = math.sin(w0)
-    alpha = 0.5 * sw0 / Q
-    b1 = 1.0 - cw0
-    b0 = b2 = b1 / 2.0
-    a0 = 1 + alpha
-    a1 = - 2.0 * cw0
-    a2 = 1 - alpha
-    return b0, b1, b2, a0, a1, a2
-
-# Design a biquad notch filter in canonical form
-def biquad_notch(fs, f, Q):
-    w0 = 2.0 * math.pi * f / fs
-    cw0 = math.cos(w0)
-    sw0 = math.sin(w0)
-    alpha = 0.5 * sw0 / Q
-    b1 = - 2.0 * cw0
-    b0 = b2 = 1.0
-    a0 = 1 + alpha
-    a1 = - 2.0 * cw0
-    a2 = 1 - alpha
-    return b0, b1, b2, a0, a1, a2
-
-# Design a biquad allpass filter in canonical form
-def biquad_apf(fs, f, Q):
-    w0 = 2.0 * math.pi * f / fs
-    cw0 = math.cos(w0)
-    sw0 = math.sin(w0)
-    alpha = 0.5 * sw0 / Q
-    b2 = 1 + alpha
-    b1 = - 2.0 * cw0
-    b0 = 1 - alpha
-    a0 = 1 + alpha
-    a1 = - 2.0 * cw0
-    a2 = 1 - alpha
-    return b0, b1, b2, a0, a1, a2
-
-# Z-transform and normalise a biquad filter, according to TMC
-def biquad_Z_tmc(T, b0, b1, b2, a0, a1, a2):
-    den = (T**2 - 2*a1 + 4*a2)
-    b2z = (b0*(T**2) + 2*b1*T + 4*b2) / den
-    b1z = (2*b0*(T**2) - 8*b2) / den
-    b0z = (b0*(T**2) - 2*b1*T + 4*b2) / den
-    a2z = (T**2 + 2*a1*T + 4*a2) / den
-    a1z = (2*(T**2) - 8*a2) / den
-    e29 = 2**29
-    b0 = round(b0z/(a0) * e29)
-    b1 = round(b1z/(a0) * e29)
-    b2 = round(b2z/(a0) * e29)
-    a1 = round(-a1z/a0 * e29)
-    a2 = round(-a2z/a0 * e29)
-    # return in the same order as the config registers
-    return a1, a2, 0, b0, b1, b2
-
-# Normalise a biquad filter, according to TMC
-def biquad_tmc(b0, b1, b2, a0, a1, a2):
-    e29 = 2**29
-    b0 = round(b0/(a0) * e29)
-    b1 = round(b1/(a0) * e29)
-    b2 = round(b2/(a0) * e29)
-    a1 = round(-a1/a0 * e29)
-    a2 = round(-a2/a0 * e29)
-    # return in the same order as the config registers
-    return a1, a2, 0, b0, b1, b2
 
 # S-IMC PI controller design, "Improved Method"
 # See https://folk.ntnu.no/skoge/publications/2012/skogestad-improved-simc-pid/PIDbook-chapter5.pdf

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1112,6 +1112,23 @@ class TMC4671:
         I = self.motor_r / (self.motor_l * self.pwmfreq)
         return P, I
 
+    def _tune_motion_pid(self, Kt, l_v, l_p):
+        Kadc = self.current_helper.current_scale * 1e-3
+        NPP = self._read_field("N_POLE_PAIRS")
+        t_d = 1.
+
+        k_v = Kadc / (Kt * math.pi)
+        t_iv = 2.*l_v + t_d
+        p_v = t_iv / (k_v * (l_v + t_d) ** 2)
+        i_v = 1. / t_iv
+
+        k_p = NPP / (256. * 50.)
+        t_ip = 2.*l_p + t_d
+        p_p = t_ip / (k_p * (l_p + t_d) ** 2)
+        i_p = 1. / t_ip
+
+        return p_v, i_v, p_p, i_p, k_v, k_p
+
     # Align motor and measure resistance and inductance on startup
     def _align_and_measure(self, offsets, print_time):
         dwell = self.printer.lookup_object('toolhead').dwell
@@ -1475,20 +1492,9 @@ class TMC4671:
                 gcmd.respond_info("Must supply KT or both HOLDING_TORQUE and HOLDING_CURRENT.")
                 return
             Kt = T_h / I_h
-        Kadc = self.current_helper.current_scale * 1e-3
-        NPP = self._read_field("N_POLE_PAIRS")
         rotation_distance, _ = self.stepper.get_rotation_distance()
-        t_d = 1.
 
-        k_v = Kadc / (Kt * math.pi)
-        t_iv = 2.*l_v + t_d
-        p_v = t_iv / (k_v * (l_v + t_d) ** 2)
-        i_v = 1. / t_iv
-
-        k_p = NPP / (256. * 50.)
-        t_ip = 2.*l_p + t_d
-        p_p = t_ip / (k_p * (l_p + t_d) ** 2)
-        i_p = 1. / t_ip
+        p_v, i_v, p_p, i_p, k_v, k_p = self._tune_motion_pid(Kt, l_v, l_p)
 
         self._write_field("PID_VELOCITY_P", self.pid_helpers["VELOCITY_P"].to_f(p_v))
         self._write_field("PID_VELOCITY_I", self.pid_helpers["VELOCITY_I"].to_f(i_v))

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -754,6 +754,13 @@ class TMC4671:
             self.cmd_TMC_DEBUG_MOTOR,
             desc=self.cmd_TMC_DEBUG_MOTOR_help,
         )
+        gcode.register_mux_command(
+            "TMC_DEBUG_TUNING",
+            "STEPPER",
+            self.name,
+            self.cmd_TMC_DEBUG_TUNING,
+            desc=self.cmd_TMC_DEBUG_TUNING_help,
+        )
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
         if self.fields6100 is not None:
@@ -1916,6 +1923,107 @@ class TMC4671:
             f"  Estimated Resistance (motor_r): {res_str}\n"
             f"  Estimated Inductance (motor_l): {ind_str}"
         )
+
+    cmd_TMC_DEBUG_TUNING_help = (
+        "Report what PID tuning helpers would compute without applying changes"
+    )
+    def cmd_TMC_DEBUG_TUNING(self, gcmd):
+        current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1800.0)
+        l_v = gcmd.get_float('LAMBDA_V', 100.0)
+        l_p = gcmd.get_float('LAMBDA_P', 400.0)
+        I_h = gcmd.get_float('HOLDING_CURRENT', None)
+        T_h = gcmd.get_float('HOLDING_TORQUE', None)
+        Kt = gcmd.get_float('KT', None)
+        if Kt is None and I_h is not None and T_h is not None:
+            Kt = T_h / I_h
+
+        lines = ["TMC 4671 '%s' Tuning Debug Report" % self.name]
+
+        # Motor parameters
+        if self.motor_r == 0.0 or self.motor_l == 0.0:
+            lines.append(
+                "Motor parameters: not yet calibrated (startup alignment pending)"
+            )
+        else:
+            lines.append(
+                "Motor parameters: R=%.4f Ω  L=%.6f H (%.3f mH)"
+                % (self.motor_r, self.motor_l, self.motor_l * 1000.0)
+            )
+
+        # --- Current PID ---
+        lines.append("")
+        lines.append(
+            "--- Current PID (bandwidth method, CURRENT_BANDWIDTH=%.1f Hz) ---"
+            % current_bandwidth
+        )
+        if self.motor_r == 0.0 or self.motor_l == 0.0:
+            lines.append("  Cannot compute: motor parameters not yet calibrated")
+        else:
+            P_new, I_new = self._tune_current_pid(current_bandwidth)
+            P_flux_cur = self.pid_helpers["FLUX_P"].from_f(
+                self._read_field("PID_FLUX_P")
+            )
+            I_flux_cur = self.pid_helpers["FLUX_I"].from_f(
+                self._read_field("PID_FLUX_I")
+            )
+            P_torq_cur = self.pid_helpers["TORQUE_P"].from_f(
+                self._read_field("PID_TORQUE_P")
+            )
+            I_torq_cur = self.pid_helpers["TORQUE_I"].from_f(
+                self._read_field("PID_TORQUE_I")
+            )
+            lines.append("  Computed:  P=%.4f  I=%.4f" % (P_new, I_new))
+            lines.append(
+                "  Active:    Flux   P=%.4f  I=%.4f" % (P_flux_cur, I_flux_cur)
+            )
+            lines.append(
+                "             Torque P=%.4f  I=%.4f" % (P_torq_cur, I_torq_cur)
+            )
+
+        # --- Motion PID ---
+        lines.append("")
+        lines.append(
+            "--- Motion PID (LAMBDA_V=%.1f  LAMBDA_P=%.1f) ---" % (l_v, l_p)
+        )
+        if Kt is None:
+            lines.append(
+                "  Supply KT or both HOLDING_CURRENT and HOLDING_TORQUE to compute"
+            )
+        else:
+            lines.append("  KT=%.5f Nm/A" % Kt)
+            p_v_new, i_v_new, p_p_new, i_p_new, k_v, k_p = self._tune_motion_pid(
+                Kt, l_v, l_p
+            )
+            p_v_cur = self.pid_helpers["VELOCITY_P"].from_f(
+                self._read_field("PID_VELOCITY_P")
+            )
+            i_v_cur = self.pid_helpers["VELOCITY_I"].from_f(
+                self._read_field("PID_VELOCITY_I")
+            )
+            p_p_cur = self.pid_helpers["POSITION_P"].from_f(
+                self._read_field("PID_POSITION_P")
+            )
+            i_p_cur = self.pid_helpers["POSITION_I"].from_f(
+                self._read_field("PID_POSITION_I")
+            )
+            lines.append(
+                "  Computed:  Velocity P=%.5f  I=%.5f" % (p_v_new, i_v_new)
+            )
+            lines.append(
+                "             Position  P=%.5f  I=%.5f" % (p_p_new, i_p_new)
+            )
+            lines.append(
+                "  Active:    Velocity P=%.5f  I=%.5f" % (p_v_cur, i_v_cur)
+            )
+            lines.append(
+                "             Position  P=%.5f  I=%.5f" % (p_p_cur, i_p_cur)
+            )
+            lines.append(
+                "  Suggested filter frequency: %d Hz"
+                % round(3.0 * self.pwmfreq / l_v)
+            )
+
+        gcmd.respond_info("\n".join(lines))
 
 def load_config_prefix(config):
     return TMC4671(config)

--- a/tmc4671_biquad.py
+++ b/tmc4671_biquad.py
@@ -1,0 +1,106 @@
+# TMC4671 biquad filter design utilities
+#
+# Copyright (C) 2024       Andrew McGregor <andrewmcgr@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import math
+from typing import NamedTuple
+
+
+class BiquadFilter(NamedTuple):
+    type: str
+    freq: int
+    slope: float
+
+
+######################################################################
+# Biquad filter utilities
+######################################################################
+
+BIQUAD_FILTER_TYPES = ['lpf', 'notch', 'apf']
+BIQUAD_FILTER_TARGETS = {
+        'flux': 'CONFIG_BIQUAD_F_ENABLE',
+        'torque': 'CONFIG_BIQUAD_T_ENABLE',
+        'velocity': 'CONFIG_BIQUAD_V_ENABLE',
+        'position': 'CONFIG_BIQUAD_X_ENABLE',
+}
+
+# Filter design formula from 4671 datasheet
+def biquad_lpf_tmc(fs, f, D):
+    w0 = 2.0 * math.pi * f / fs
+    b2 = b1 = 0.0
+    b0 = 1.0
+    a2 = 1.0 / (w0**2)
+    a1 = 2.0 * D / w0
+    a0 = 1.0
+    return b0, b1, b2, a0, a1, a2
+
+# Filter design formulae from https://www.w3.org/TR/audio-eq-cookbook/
+
+# Design a biquad low pass filter in canonical form
+def biquad_lpf(fs, f, Q):
+    w0 = 2.0 * math.pi * f / fs
+    cw0 = math.cos(w0)
+    sw0 = math.sin(w0)
+    alpha = 0.5 * sw0 / Q
+    b1 = 1.0 - cw0
+    b0 = b2 = b1 / 2.0
+    a0 = 1 + alpha
+    a1 = - 2.0 * cw0
+    a2 = 1 - alpha
+    return b0, b1, b2, a0, a1, a2
+
+# Design a biquad notch filter in canonical form
+def biquad_notch(fs, f, Q):
+    w0 = 2.0 * math.pi * f / fs
+    cw0 = math.cos(w0)
+    sw0 = math.sin(w0)
+    alpha = 0.5 * sw0 / Q
+    b1 = - 2.0 * cw0
+    b0 = b2 = 1.0
+    a0 = 1 + alpha
+    a1 = - 2.0 * cw0
+    a2 = 1 - alpha
+    return b0, b1, b2, a0, a1, a2
+
+# Design a biquad allpass filter in canonical form
+def biquad_apf(fs, f, Q):
+    w0 = 2.0 * math.pi * f / fs
+    cw0 = math.cos(w0)
+    sw0 = math.sin(w0)
+    alpha = 0.5 * sw0 / Q
+    b2 = 1 + alpha
+    b1 = - 2.0 * cw0
+    b0 = 1 - alpha
+    a0 = 1 + alpha
+    a1 = - 2.0 * cw0
+    a2 = 1 - alpha
+    return b0, b1, b2, a0, a1, a2
+
+# Z-transform and normalise a biquad filter, according to TMC
+def biquad_Z_tmc(T, b0, b1, b2, a0, a1, a2):
+    den = (T**2 - 2*a1 + 4*a2)
+    b2z = (b0*(T**2) + 2*b1*T + 4*b2) / den
+    b1z = (2*b0*(T**2) - 8*b2) / den
+    b0z = (b0*(T**2) - 2*b1*T + 4*b2) / den
+    a2z = (T**2 + 2*a1*T + 4*a2) / den
+    a1z = (2*(T**2) - 8*a2) / den
+    e29 = 2**29
+    b0 = round(b0z/(a0) * e29)
+    b1 = round(b1z/(a0) * e29)
+    b2 = round(b2z/(a0) * e29)
+    a1 = round(-a1z/a0 * e29)
+    a2 = round(-a2z/a0 * e29)
+    # return in the same order as the config registers
+    return a1, a2, 0, b0, b1, b2
+
+# Normalise a biquad filter, according to TMC
+def biquad_tmc(b0, b1, b2, a0, a1, a2):
+    e29 = 2**29
+    b0 = round(b0/(a0) * e29)
+    b1 = round(b1/(a0) * e29)
+    b2 = round(b2/(a0) * e29)
+    a1 = round(-a1/a0 * e29)
+    a2 = round(-a2/a0 * e29)
+    # return in the same order as the config registers
+    return a1, a2, 0, b0, b1, b2


### PR DESCRIPTION
## Summary

Three independent improvements:

### 1. Add TMC_DEBUG_TUNING command
A dry-run diagnostic command that runs the current and motion PID tuning helpers and reports computed vs. active register values — without writing anything to the chip. Useful for validating tuning parameters before applying them.

Parameters:
- `CURRENT_BANDWIDTH` (default 1800.0 Hz)
- `LAMBDA_V` (default 100.0)
- `LAMBDA_P` (default 400.0)
- `KT` (optional, motor torque constant)
- `HOLDING_CURRENT` + `HOLDING_TORQUE` (optional, derives Kt)

Guards against uncalibrated motor parameters (motor_r/motor_l == 0).

### 2. Add G-code command reference section to README
Documents all 13 G-code commands with synopsis, parameter tables, and descriptions:
`INIT_TMC`, `SET_TMC_CURRENT`, `TMC_TUNE_PID`, `TMC_TUNE_MOTION_PID`, `TMC_DEBUG_TUNING`, `SET_TMC_BIQUAD_FILTER`, `SET_TMC_FIELD`, `DUMP_TMC`, `DUMP_TMC6100`, `TMC_DEBUG_VOLTAGE`, `TMC_DEBUG_CURRENT`, `TMC_DEBUG_MOTOR`, `TMC_DEBUG_MOVE`.

### 3. Note G-code command documentation requirement in AGENTS.md
Adds a convention requiring that any new or changed G-code command be reflected in the README command reference.