### PR TITLE
Biquad filter refactor, TMC_DEBUG_TUNING command, inductance fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ The command also suggests biquad filter frequencies but does not apply them.
 Report what the PID tuning helpers would compute given the current motor parameters, without writing anything to the controller. Compares computed values against the currently active register values.
 
 ```
-TMC_DEBUG_TUNING STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [LAMBDA_V=<val>] [LAMBDA_P=<val>] [KT=<nm/a>]
+TMC_DEBUG_TUNING STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [LAMBDA_V=<val>] [LAMBDA_P=<val>] [KT=<nm/a>] [R=<ohm>] [L=<henry>]
 TMC_DEBUG_TUNING STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [...]
 ```
 
@@ -235,8 +235,10 @@ TMC_DEBUG_TUNING STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [...]
 | `LAMBDA_P` | 400.0 | Position loop time constant for the motion PID calculation. |
 | `KT` | — | Motor torque constant in Nm/A (required for motion PID section). |
 | `HOLDING_CURRENT` + `HOLDING_TORQUE` | — | Alternative way to supply Kt. |
+| `R` | — | Override motor winding resistance in Ω. Defaults to the measured value. |
+| `L` | — | Override motor winding inductance in H. Defaults to the measured value. |
 
-If motor R and L have not yet been measured (startup alignment pending), the current PID section reports that instead of computing. The motion PID section is skipped if no torque constant is provided.
+If motor R and L have not yet been measured (startup alignment pending), the current PID section reports that instead of computing. Providing `R` or `L` overrides the measured value for the computation without changing what is stored; the output labels overridden values accordingly. The motion PID section is skipped if no torque constant is provided.
 
 ### SET_TMC_BIQUAD_FILTER
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1141,7 +1141,7 @@ class TMC4671:
         dwell = self.printer.lookup_object('toolhead').dwell
         old_phi_e_selection = self._read_field("PHI_E_SELECTION")
 
-        # Temporarily disable biquad filters during measurement to prevent attenuation of the 4 kHz signal
+        # Temporarily disable biquad filters during measurement to prevent attenuation of the 1 kHz signal
         for register in BIQUAD_FILTER_TARGETS.values():
             self.disable_biquad(register)
 
@@ -1174,7 +1174,6 @@ class TMC4671:
         # Average current readings to filter mechanical ringing and noise
         iux, iwy, _ = self._average_currents(20, 0.005)
         logging.info("TMC 4671 '%s' alignment averaged I: Ux=%0.4fA, Wy=%0.4fA", self.stepper_name, iux, iwy)
-        test2_U / (self.vm_range / self.voltage_scale)
         R = test2_U * self.voltage_scale / (self.vm_range * max(abs(iux), abs(iwy)))
         self.motor_r = R
         logging.info("TMC 4671 '%s' est. motor R=%g Ω", self.stepper_name, R)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1099,10 +1099,14 @@ class TMC4671:
     def _tune_torque_pid(self, test_existing, derate, print_time):
         return self._tune_pid("TORQUE", 1.0, derate, test_existing, print_time)
 
-    def _tune_current_pid(self, current_bandwidth):
+    def _tune_current_pid(self, current_bandwidth, motor_r=None, motor_l=None):
+        if motor_r is None:
+            motor_r = self.motor_r
+        if motor_l is None:
+            motor_l = self.motor_l
         # 1. Calculate continuous physical gains
         omega_bw = 2.0 * math.pi * current_bandwidth
-        Kp_physical = omega_bw * self.motor_l
+        Kp_physical = omega_bw * motor_l
 
         # 2. Extract hardware loop scaling factors
         # current_scale is in mA/LSB, convert to A/LSB
@@ -1116,7 +1120,7 @@ class TMC4671:
 
         # 4. Calculate I as an analytical plant ratio for Advanced Mode (Serial structure)
         # I = R / (L * f_pwm)
-        I = self.motor_r / (self.motor_l * self.pwmfreq)
+        I = motor_r / (motor_l * self.pwmfreq)
         return P, I
 
     def _tune_motion_pid(self, Kt, l_v, l_p):
@@ -1934,20 +1938,27 @@ class TMC4671:
         I_h = gcmd.get_float('HOLDING_CURRENT', None)
         T_h = gcmd.get_float('HOLDING_TORQUE', None)
         Kt = gcmd.get_float('KT', None)
+        r_override = gcmd.get_float('R', None, minval=0.0)
+        l_override = gcmd.get_float('L', None, minval=0.0)
         if Kt is None and I_h is not None and T_h is not None:
             Kt = T_h / I_h
+
+        eff_r = r_override if r_override is not None else self.motor_r
+        eff_l = l_override if l_override is not None else self.motor_l
 
         lines = ["TMC 4671 '%s' Tuning Debug Report" % self.name]
 
         # Motor parameters
-        if self.motor_r == 0.0 or self.motor_l == 0.0:
+        if eff_r == 0.0 or eff_l == 0.0:
             lines.append(
                 "Motor parameters: not yet calibrated (startup alignment pending)"
             )
         else:
+            r_src = " (override)" if r_override is not None else ""
+            l_src = " (override)" if l_override is not None else ""
             lines.append(
-                "Motor parameters: R=%.4f Ω  L=%.6f H (%.3f mH)"
-                % (self.motor_r, self.motor_l, self.motor_l * 1000.0)
+                "Motor parameters: R=%.4f Ω%s  L=%.6f H (%.3f mH)%s"
+                % (eff_r, r_src, eff_l, eff_l * 1000.0, l_src)
             )
 
         # --- Current PID ---
@@ -1956,10 +1967,12 @@ class TMC4671:
             "--- Current PID (bandwidth method, CURRENT_BANDWIDTH=%.1f Hz) ---"
             % current_bandwidth
         )
-        if self.motor_r == 0.0 or self.motor_l == 0.0:
+        if eff_r == 0.0 or eff_l == 0.0:
             lines.append("  Cannot compute: motor parameters not yet calibrated")
         else:
-            P_new, I_new = self._tune_current_pid(current_bandwidth)
+            P_new, I_new = self._tune_current_pid(
+                current_bandwidth, motor_r=eff_r, motor_l=eff_l
+            )
             P_flux_cur = self.pid_helpers["FLUX_P"].from_f(
                 self._read_field("PID_FLUX_P")
             )

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1184,6 +1184,7 @@ class TMC4671:
         self._write_field("PWM_CHOP", 7) # Re-enable the gate driver (crucial to apply AC voltage)
         self._write_field("PHI_E_SELECTION", 2)  # Open Loop
         self._write_field("OPENLOOP_VELOCITY_TARGET", 0)
+        self._write_field("OPENLOOP_VELOCITY_ACTUAL", 0)  # Reset residual velocity from prior run
         self._write_field("UQ_EXT", 0)
 
         # Automated AC Voltage Calculation


### PR DESCRIPTION
## Summary

### Biquad filter refactor
- Extract biquad filter utilities into `tmc4671_biquad.py` (symlinked via install script)
- Update AGENTS.md to document the new module

### TMC_DEBUG_TUNING command
- Add read-only debug command that reports what PID tuning helpers would compute without applying changes
- Compares computed values against currently active register values
- Accepts `CURRENT_BANDWIDTH`, `LAMBDA_V`, `LAMBDA_P`, `KT`/`HOLDING_CURRENT`+`HOLDING_TORQUE`, and now `R`/`L` overrides for motor parameters

### Inductance measurement fixes
- **Bug fix**: `OPENLOOP_VELOCITY_ACTUAL` persists across software restarts (chip registers survive Klipper restart but not power cycle). Previous runs left the velocity accumulator spinning at the 1 kHz test frequency, causing the next DC phase to measure AC impedance instead of DC resistance — resulting in `motor_l = 0.0`. Fixed by writing 0 to the RW register at the start of the DC phase.
- Remove dead statement (computed value immediately discarded)
- Fix stale comment (referred to '4 kHz signal'; snip actual test frequency is 1 kHz)

### Documentation
- Add G-code command reference section to README covering all 13 commands
- Note G-code command documentation requirement in AGENTS.md