### PR TITLE
Tune flux and torque current loops separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,22 +184,31 @@ Without `CURRENT`, reports the currently active limit. With `CURRENT`, updates t
 
 ### TMC_TUNE_PID
 
-Autotune flux and torque PID coefficients and queue the results for `SAVE_CONFIG`.
+Autotune flux and torque current-loop PID coefficients separately and queue the results for `SAVE_CONFIG`. With the bandwidth method (default), the flux and torque biquad filters are automatically configured as LPF at the respective tuned bandwidth.
 
 ```
-TMC_TUNE_PID STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [SIMC=<0|1>] [CHECK=<0|1>] [DERATE=<factor>]
+TMC_TUNE_PID STEPPER=stepper_x [FLUX_BANDWIDTH=<hz>] [TORQUE_BANDWIDTH=<hz>] [CURRENT_BANDWIDTH=<hz>] [SIMC=<0|1>] [CHECK=<0|1>] [DERATE=<factor>]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
-| `CURRENT_BANDWIDTH` | 1800.0 | Target closed-loop current bandwidth in Hz. Higher values are faster but noisier. |
-| `SIMC` | 0 | Use S-IMC setpoint-change experiment instead of the bandwidth method. |
+| `FLUX_BANDWIDTH` | `CURRENT_BANDWIDTH` | Target closed-loop bandwidth in Hz for the flux (d-axis) current loop. |
+| `TORQUE_BANDWIDTH` | `CURRENT_BANDWIDTH` | Target closed-loop bandwidth in Hz for the torque (q-axis) current loop. |
+| `CURRENT_BANDWIDTH` | 1800.0 | Fallback bandwidth when `FLUX_BANDWIDTH` or `TORQUE_BANDWIDTH` are not set. |
+| `SIMC` | 0 | Use S-IMC setpoint-change experiment instead of the bandwidth method. Flux and torque loops are each tuned with a separate experiment. |
 | `CHECK` | 0 | With `SIMC=1`: test the *existing* gains instead of starting from scratch. |
 | `DERATE` | 1.6 | With `SIMC=1`: initial gain derate factor. |
 
-The default (bandwidth) method derives P and I analytically from the measured motor R and L. The `SIMC` method runs a live setpoint-change experiment and fits a first-order-plus-dead-time model — more accurate but takes longer and requires the motor to be active.
+The bandwidth method derives P and I analytically from the measured motor R and L. The `SIMC` method runs a live setpoint-change experiment per loop and fits a first-order-plus-dead-time model — more accurate but slower and requires the motor to be active.
 
-Output example: `PID stepper_x parameters: Kc=9.66 Ki=0.485`
+Output example:
+```
+PID stepper_x parameters:
+  Flux biquad LPF: 1800 Hz
+  Torque biquad LPF: 1800 Hz
+  Flux:   Kc=9.6600 Ki=0.4850
+  Torque: Kc=9.6600 Ki=0.4850
+```
 
 ### TMC_TUNE_MOTION_PID
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ TMC_TUNE_PID STEPPER=stepper_x [FLUX_BANDWIDTH=<hz>] [TORQUE_BANDWIDTH=<hz>] [CU
 |---|---|---|
 | `FLUX_BANDWIDTH` | `CURRENT_BANDWIDTH` | Target closed-loop bandwidth in Hz for the flux (d-axis) current loop. |
 | `TORQUE_BANDWIDTH` | `CURRENT_BANDWIDTH` | Target closed-loop bandwidth in Hz for the torque (q-axis) current loop. |
-| `CURRENT_BANDWIDTH` | 1800.0 | Fallback bandwidth when `FLUX_BANDWIDTH` or `TORQUE_BANDWIDTH` are not set. |
+| `CURRENT_BANDWIDTH` | 1200.0 | Fallback bandwidth when `FLUX_BANDWIDTH` or `TORQUE_BANDWIDTH` are not set. 1800 Hz is aggressive and noisy; 1200 Hz is a safer default. |
 | `SIMC` | 0 | Use S-IMC setpoint-change experiment instead of the bandwidth method. Flux and torque loops are each tuned with a separate experiment. |
 | `CHECK` | 0 | With `SIMC=1`: test the *existing* gains instead of starting from scratch. |
 | `DERATE` | 1.6 | With `SIMC=1`: initial gain derate factor. |
@@ -204,8 +204,8 @@ The bandwidth method derives P and I analytically from the measured motor R and 
 Output example:
 ```
 PID stepper_x parameters:
-  Flux biquad LPF: 1800 Hz
-  Torque biquad LPF: 1800 Hz
+  Flux biquad LPF: 1200 Hz
+  Torque biquad LPF: 1200 Hz
   Flux:   Kc=9.6600 Ki=0.4850
   Torque: Kc=9.6600 Ki=0.4850
 ```
@@ -240,7 +240,7 @@ TMC_DEBUG_TUNING STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [...]
 
 | Parameter | Default | Description |
 |---|---|---|
-| `CURRENT_BANDWIDTH` | 1800.0 | Bandwidth in Hz for the current PID calculation. |
+| `CURRENT_BANDWIDTH` | 1200.0 | Bandwidth in Hz for the current PID calculation. |
 | `LAMBDA_V` | 100.0 | Velocity loop time constant for the motion PID calculation. |
 | `LAMBDA_P` | 400.0 | Position loop time constant for the motion PID calculation. |
 | `KT` | — | Motor torque constant in Nm/A (required for motion PID section). |

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Without `CURRENT`, reports the currently active limit. With `CURRENT`, updates t
 
 ### TMC_TUNE_PID
 
-Autotune flux and torque current-loop PID coefficients separately and queue the results for `SAVE_CONFIG`. With the bandwidth method (default), the flux and torque biquad filters are automatically configured as LPF at the respective tuned bandwidth.
+Autotune flux and torque current-loop PID coefficients separately and queue the results for `SAVE_CONFIG`. With the bandwidth method (default), the flux and torque biquad filters are automatically configured as LPF at the respective tuned bandwidth and their settings are also staged for `SAVE_CONFIG`.
 
 ```
 TMC_TUNE_PID STEPPER=stepper_x [FLUX_BANDWIDTH=<hz>] [TORQUE_BANDWIDTH=<hz>] [CURRENT_BANDWIDTH=<hz>] [SIMC=<0|1>] [CHECK=<0|1>] [DERATE=<factor>]

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1813,8 +1813,10 @@ class TMC4671:
                 P_flux, I_flux = self._tune_flux_pid(test_existing, derate, print_time)
                 P_torque, I_torque = self._tune_torque_pid(test_existing, derate, print_time)
             else:
-                P_flux, I_flux = self._tune_current_pid(flux_bandwidth)
-                P_torque, I_torque = self._tune_current_pid(torque_bandwidth)
+                flux_l = self.motor_ld if self.motor_ld != 0.0 else self.motor_l
+                torque_l = self.motor_lq if self.motor_lq != 0.0 else self.motor_l
+                P_flux, I_flux = self._tune_current_pid(flux_bandwidth, motor_l=flux_l)
+                P_torque, I_torque = self._tune_current_pid(torque_bandwidth, motor_l=torque_l)
                 flux_filter = BiquadFilter(
                     type='lpf', freq=round(flux_bandwidth),
                     slope=self.biquad_filters['flux'].slope)
@@ -2253,6 +2255,10 @@ class TMC4671:
 
         eff_r = r_override if r_override is not None else self.motor_r
         eff_l = l_override if l_override is not None else self.motor_l
+        eff_ld = l_override if l_override is not None else (
+            self.motor_ld if self.motor_ld != 0.0 else self.motor_l)
+        eff_lq = l_override if l_override is not None else (
+            self.motor_lq if self.motor_lq != 0.0 else self.motor_l)
 
         lines = ["TMC 4671 '%s' Tuning Debug Report" % self.name]
 
@@ -2266,7 +2272,9 @@ class TMC4671:
             l_src = " (override)" if l_override is not None else ""
             lines.append(
                 "Motor parameters: R=%.4f Ω%s  L=%.6f H (%.3f mH)%s"
-                % (eff_r, r_src, eff_l, eff_l * 1000.0, l_src)
+                "  Ld=%.6f H (%.3f mH)  Lq=%.6f H (%.3f mH)"
+                % (eff_r, r_src, eff_l, eff_l * 1000.0, l_src,
+                   eff_ld, eff_ld * 1000.0, eff_lq, eff_lq * 1000.0)
             )
 
         # --- Current PID ---
@@ -2278,8 +2286,11 @@ class TMC4671:
         if eff_r == 0.0 or eff_l == 0.0:
             lines.append("  Cannot compute: motor parameters not yet calibrated")
         else:
-            P_new, I_new = self._tune_current_pid(
-                current_bandwidth, motor_r=eff_r, motor_l=eff_l
+            P_flux_new, I_flux_new = self._tune_current_pid(
+                current_bandwidth, motor_r=eff_r, motor_l=eff_ld
+            )
+            P_torq_new, I_torq_new = self._tune_current_pid(
+                current_bandwidth, motor_r=eff_r, motor_l=eff_lq
             )
             P_flux_cur = self.pid_helpers["FLUX_P"].from_f(
                 self.fields.PID_FLUX_P.read()
@@ -2293,7 +2304,12 @@ class TMC4671:
             I_torq_cur = self.pid_helpers["TORQUE_I"].from_f(
                 self.fields.PID_TORQUE_I.read()
             )
-            lines.append("  Computed:  P=%.4f  I=%.4f" % (P_new, I_new))
+            lines.append(
+                "  Computed:  Flux   P=%.4f  I=%.4f" % (P_flux_new, I_flux_new)
+            )
+            lines.append(
+                "             Torque P=%.4f  I=%.4f" % (P_torq_new, I_torq_new)
+            )
             lines.append(
                 "  Active:    Flux   P=%.4f  I=%.4f" % (P_flux_cur, I_flux_cur)
             )

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1802,7 +1802,7 @@ class TMC4671:
         test_existing = gcmd.get_int('CHECK', 0)
         derate = gcmd.get_float('DERATE', 1.6)
         simc_flag = gcmd.get_int('SIMC', 0)
-        current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1800.0)
+        current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1200.0)
         flux_bandwidth = gcmd.get_float('FLUX_BANDWIDTH', current_bandwidth)
         torque_bandwidth = gcmd.get_float('TORQUE_BANDWIDTH', current_bandwidth)
         logging.info("TMC_TUNE_PID %s (SIMC=%d, flux_bw=%.1f, torque_bw=%.1f)",
@@ -2242,7 +2242,7 @@ class TMC4671:
         "Report what PID tuning helpers would compute without applying changes"
     )
     def cmd_TMC_DEBUG_TUNING(self, gcmd):
-        current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1800.0)
+        current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1200.0)
         l_v = gcmd.get_float('LAMBDA_V', 100.0)
         l_p = gcmd.get_float('LAMBDA_P', 400.0)
         I_h = gcmd.get_float('HOLDING_CURRENT', None)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1840,6 +1840,15 @@ class TMC4671:
             configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (I_flux,))
             configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (P_torque,))
             configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (I_torque,))
+            if not simc_flag:
+                for target in ('flux', 'torque'):
+                    bf = self.biquad_filters[target]
+                    configfile.set(cfgname, 'biquad_%s_filter' % (target,),
+                                   bf.type)
+                    configfile.set(cfgname, 'biquad_%s_frequency' % (target,),
+                                   "%d" % (bf.freq,))
+                    configfile.set(cfgname, 'biquad_%s_slope' % (target,),
+                                   "%.6g" % (bf.slope,))
 
         biquad_msg = ""
         if not simc_flag:

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1815,6 +1815,10 @@ class TMC4671:
             else:
                 flux_l = self.motor_ld if self.motor_ld != 0.0 else self.motor_l
                 torque_l = self.motor_lq if self.motor_lq != 0.0 else self.motor_l
+                if flux_l == 0.0 or torque_l == 0.0:
+                    raise gcmd.error(
+                        "Motor inductance not measured. Run TMC_ALIGN_MOTOR "
+                        "or FIRMWARE_RESTART to trigger startup calibration first.")
                 P_flux, I_flux = self._tune_current_pid(flux_bandwidth, motor_l=flux_l)
                 P_torque, I_torque = self._tune_current_pid(torque_bandwidth, motor_l=torque_l)
                 flux_filter = BiquadFilter(

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1662,16 +1662,6 @@ class TMC4671:
         Kc *= 2.0
         Ki = 2.0*Kc/(taui*self.pwmfreq)
         logging.info("TMC 4671 %s %s PID coefficients Kc=%g, Ti=%g (Ki=%g)"%(self.name, X, Kc, taui, Ki))
-        if not test_existing:
-            getattr(self.fields, "PID_%s_P"%X).write(self.pid_helpers["%s_P"%X].to_f(Kc))
-            getattr(self.fields, "PID_%s_I"%X).write(self.pid_helpers["%s_I"%X].to_f(Ki))
-            # Store results for SAVE_CONFIG
-            cfgname = "tmc4671 %s" % (self.name,)
-            configfile = self.printer.lookup_object('configfile')
-            configfile.set(cfgname, 'foc_PID_FLUX_P', "%.3f" % (Kc,))
-            configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (Ki,))
-            configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (Kc,))
-            configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (Ki,))
         return Kc, Ki
 
     def _dump_pid(self, n, X):
@@ -1813,30 +1803,55 @@ class TMC4671:
         derate = gcmd.get_float('DERATE', 1.6)
         simc_flag = gcmd.get_int('SIMC', 0)
         current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1800.0)
-        logging.info("TMC_TUNE_PID %s (SIMC=%d, BANDWIDTH=%.1f)", self.name, simc_flag, current_bandwidth)
+        flux_bandwidth = gcmd.get_float('FLUX_BANDWIDTH', current_bandwidth)
+        torque_bandwidth = gcmd.get_float('TORQUE_BANDWIDTH', current_bandwidth)
+        logging.info("TMC_TUNE_PID %s (SIMC=%d, flux_bw=%.1f, torque_bw=%.1f)",
+                     self.name, simc_flag, flux_bandwidth, torque_bandwidth)
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         with self.mutex:
             if simc_flag:
-                P, I = self._tune_flux_pid(test_existing, derate, print_time)
+                P_flux, I_flux = self._tune_flux_pid(test_existing, derate, print_time)
+                P_torque, I_torque = self._tune_torque_pid(test_existing, derate, print_time)
             else:
-                P, I = self._tune_current_pid(current_bandwidth)
-            self.fields.PID_FLUX_P.write(self.pid_helpers["FLUX_P"].to_f(P))
+                P_flux, I_flux = self._tune_current_pid(flux_bandwidth)
+                P_torque, I_torque = self._tune_current_pid(torque_bandwidth)
+                flux_filter = BiquadFilter(
+                    type='lpf', freq=round(flux_bandwidth),
+                    slope=self.biquad_filters['flux'].slope)
+                self.biquad_filters['flux'] = flux_filter
+                self._setup_filter(BIQUAD_FILTER_TARGETS['flux'], flux_filter)
+                torque_filter = BiquadFilter(
+                    type='lpf', freq=round(torque_bandwidth),
+                    slope=self.biquad_filters['torque'].slope)
+                self.biquad_filters['torque'] = torque_filter
+                self._setup_filter(BIQUAD_FILTER_TARGETS['torque'], torque_filter)
 
-            self.fields.PID_FLUX_I.write(self.pid_helpers["FLUX_I"].to_f(I))
-            self.fields.PID_TORQUE_P.write(self.pid_helpers["TORQUE_P"].to_f(P))
-            self.fields.PID_TORQUE_I.write(self.pid_helpers["TORQUE_I"].to_f(I))
+            self.fields.PID_FLUX_P.write(self.pid_helpers["FLUX_P"].to_f(P_flux))
+            self.fields.PID_FLUX_I.write(self.pid_helpers["FLUX_I"].to_f(I_flux))
+            self.fields.PID_TORQUE_P.write(self.pid_helpers["TORQUE_P"].to_f(P_torque))
+            self.fields.PID_TORQUE_I.write(self.pid_helpers["TORQUE_I"].to_f(I_torque))
 
             # Store results for SAVE_CONFIG
             cfgname = "tmc4671 %s" % (self.name,)
             configfile = self.printer.lookup_object('configfile')
-            configfile.set(cfgname, 'foc_PID_FLUX_P', "%.3f" % (P,))
-            configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (I,))
-            configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (P,))
-            configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (I,))
+            configfile.set(cfgname, 'foc_PID_FLUX_P', "%.3f" % (P_flux,))
+            configfile.set(cfgname, 'foc_PID_FLUX_I', "%.3f" % (I_flux,))
+            configfile.set(cfgname, 'foc_PID_TORQUE_P', "%.3f" % (P_torque,))
+            configfile.set(cfgname, 'foc_PID_TORQUE_I', "%.3f" % (I_torque,))
+
+        biquad_msg = ""
+        if not simc_flag:
+            biquad_msg = (
+                "\n  Flux biquad LPF: %d Hz"
+                "\n  Torque biquad LPF: %d Hz"
+                % (round(flux_bandwidth), round(torque_bandwidth)))
         gcmd.respond_info(
-            "PID %s parameters: Kc=%.2f Ki=%.3f\n"
+            "PID %s parameters:%s\n"
+            "  Flux:   Kc=%.4f Ki=%.4f\n"
+            "  Torque: Kc=%.4f Ki=%.4f\n"
             "The SAVE_CONFIG command will update the printer config file\n"
-            "with these parameters and restart the printer." % (self.name, P, I))
+            "with these parameters and restart the printer."
+            % (self.name, biquad_msg, P_flux, I_flux, P_torque, I_torque))
 
     cmd_TMC_DEBUG_MOVE_help = "Test TMC motion mode (motor must be free to move)"
     def cmd_TMC_DEBUG_MOVE(self, gcmd):
@@ -2202,14 +2217,23 @@ class TMC4671:
         ld_str = f"{self.motor_ld:.6f} H ({self.motor_ld * 1000.0:.3f} mH)" if self.motor_ld != 0.0 else "Not yet calibrated / measured"
         lq_str = f"{self.motor_lq:.6f} H ({self.motor_lq * 1000.0:.3f} mH)" if self.motor_lq != 0.0 else "Not yet calibrated / measured"
         sal_str = f"{self.motor_saliency:.4f}" if self.motor_saliency != 1.0 else "Not yet calibrated / measured"
-        
+
+        def _biquad_str(target):
+            bf = self.biquad_filters[target]
+            if bf.freq == 0:
+                return "disabled"
+            return f"{bf.type.upper()} {bf.freq} Hz (slope={bf.slope:.4f})"
+
         gcmd.respond_info(
             f"TMC 4671 '{self.name}' Motor Debug Report:\n"
             f"  Estimated Resistance (motor_r): {res_str}\n"
             f"  Estimated Inductance (motor_l): {ind_str}\n"
             f"  Estimated Ld Inductance (motor_ld): {ld_str}\n"
             f"  Estimated Lq Inductance (motor_lq): {lq_str}\n"
-            f"  Saliency Ratio (motor_saliency): {sal_str}"
+            f"  Saliency Ratio (motor_saliency): {sal_str}\n"
+            f"  Current Loop Filters:\n"
+            f"    Flux:   {_biquad_str('flux')}\n"
+            f"    Torque: {_biquad_str('torque')}"
         )
 
     cmd_TMC_DEBUG_TUNING_help = (


### PR DESCRIPTION
## Summary

Tune the flux and torque current PID loops separately, with supporting improvements to biquad filter handling and robustness.

## Changes

### Separate current loop tuning (`c93fefa`)
- `TMC_TUNE_PID` now accepts `FLUX_BANDWIDTH` and `TORQUE_BANDWIDTH` parameters in addition to `CURRENT_BANDWIDTH` (fallback), allowing the d-axis and q-axis loops to be tuned to different bandwidths
- SIMC method: flux and torque loops are each tuned with a separate experiment
- Bandwidth method: flux loop uses measured `Ld`, torque loop uses `Lq` (falls back to `motor_l` if not yet measured)
- After bandwidth tuning, biquad LPF filters are automatically set to the respective tuned bandwidths
- `TMC_DEBUG_MOTOR` now reports the current loop biquad filter state (type, frequency) for flux and torque
- `_tune_pid` simplified to pure computation returning `(Kc, Ki)` only; snip callers handle field writes and SAVE_CONFIG

### Pass measured Ld/Lq into debug tuning (`b26fe32`)
- `TMC_DEBUG_TUNING` now uses `motor_ld`/`motor_lq` when computing separate flux and torque P/I values, matching what `TMC_TUNE_PID` would apply

### Default bandwidth 1800 → 1200 Hz (`a3fa1b7`)
- 1800 Hz is aggressive and noisy for most NEMA 17 steppers; snip 1200 Hz is a safer default

### Stage biquad filter settings for SAVE_CONFIG (`c8a9a68`)
- When using the bandwidth method, `TMC_TUNE_PID` also stages `biquad_flux_filter`, `biquad_flux_frequency`, `biquad_flux_slope`, `biquad_torque_filter`, `biquad_torque_frequency`, `biquad_torque_slope` for `SAVE_CONFIG`, so a single save captures both PID gains and filter settings

### Guard against ZeroDivisionError (`f86fb57`)
- `TMC_TUNE_PID` now raises a clear error if motor inductance is not yet measured, instead of crashing to shutdown with `ZeroDivisionError`

## README

`TMC_TUNE_PID` and `TMC_DEBUG_TUNING` G-code reference sections updated to document the new parameters and behaviour.