### PR TITLE
Sensorless homing

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,10 @@ full_steps_per_rotation: 4096
 step_pin: tmcx:PB11
 dir_pin: tmcx:PA0
 enable_pin: tmcx:PE7
-endstop_pin: ^MCU_M1_STOP
+endstop_pin: ^MCU_M1_STOP                    # physical endstop
+#endstop_pin: tmc4671_stepper_x:virtual_endstop  # sensorless homing (diag_pin required)
 homing_speed: 40
-homing_retract_dist: 0
+homing_retract_dist: 5   # must not be 0 for sensorless homing; fine to reduce for physical endstop
 position_min: 0
 position_max: 350
 position_endstop: 350
@@ -98,6 +99,8 @@ spi_bus: spi1
 spi_speed: 1000000
 current_scale_ma_lsb: 1.155
 adc_temp_reg: AGPI_B
+#diag_pin: ^MCU_DIAG_PIN   # sensorless homing: MCU GPIO connected to driver STATUS output
+#homing_current: 0.5       # sensorless homing: start here, increase if false triggers (see Sensorless homing section)
 run_current: 3.54
 flux_current: 0.0
 foc_motor_type: 2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Klipper driver features:
 * PID configuration for the velocity and position loops (manual tuning required, for now)
 * ADC autocalibration
 * Encoder autoinitialisation for relative encoders, or absolute encoders not indexed to the electrical phase of the motor
-* Sensorless homing (not currently working) by setting a low homing current and detecting failure to track the commanded position within the driver
+* Sensorless homing by setting a low homing current and using `PID_IQ_TARGET_LIMIT` to detect stall within a few PWM cycles of contact
 * On-driver limit switch pin support
 * Optional TMC6100 output driver initialisation support (requred for the eval board, not used for OpenFFBoard or Ouroboros)
 * Virtual steps-per-revolution and microsteps. Klipper treats the TMC 4671 as if it were a conventional stepper driver, all servo activity takes place in hardware. Thus the steps and microsteps in the configuration have no particular relation to the motor, and instead are translated to position angle targets within the TMC 4671.
@@ -171,6 +171,61 @@ TMC_TUNE_MOTION_PID LAMBDA_V=80 LAMBDA_P=180 KT=0.022 STEPPER=stepper_y
 depending on whether you know a KT value (in nM/A) or holding specifications. Lambda_v and Lambda_p are measures of how aggressive the tuning will be. Lambda_v can go from approximately 45 up, and Lambda_p should be at least twice Lambda_v; the default values are Lambda_v=100 and Lambda_p=400. `SAVE_CONFIG` will save the tuning values. The command will also suggest filter frequencies, but will not apply them.
 
 If the motors make noise at rest after autotuning, increase the Lambda values. If not, consider decreasing them; the minimum value that remains quiet at rest is likely also the optimal value.
+
+## Sensorless homing
+
+The TMC 4671 can signal stall detection via its STATUS output pin, enabling sensorless homing without a physical endstop.
+
+**How it works:** at the start of a homing move the driver programs a STATUS_MASK into the chip. When the motor stalls, the current loop immediately demands more torque than `homing_current` allows — the `PID_IQ_TARGET_LIMIT` flag fires within a few PWM cycles (~40 µs at 25 kHz), the STATUS pin goes high, the MCU endstop triggers, and the homing move stops. This is a P-term response — no integrator wind-up required, so detection is nearly instantaneous at contact.
+
+### Hardware
+
+Connect the STATUS output of the TMC 4671 (or driver board) to a free MCU GPIO. Check your board schematic for the pin and its polarity; many boards need a pull-up (`^`).
+
+### Configuration
+
+In `[stepper_x]`, point the endstop at the virtual endstop and set a non-zero retract distance:
+
+```ini
+[stepper_x]
+endstop_pin: tmc4671_stepper_x:virtual_endstop
+homing_retract_dist: 5
+```
+
+In `[tmc4671 stepper_x]`, add the diag pin and homing current:
+
+```ini
+diag_pin: ^MCU_DIAG_PIN   # MCU GPIO connected to the STATUS output; ^ if open-drain
+homing_current: 0.5       # starting point — tune as described below
+```
+
+### Tuning homing_current
+
+`homing_current` is written to `PID_TORQUE_FLUX_LIMITS` at the start of each homing move. The detection fires the instant the velocity PID demands more current than this limit. During free motion the demanded current is only what is needed to overcome friction and inertia; at stall it saturates immediately.
+
+The correct value is **just above the peak current the motor needs to move freely at homing speed:**
+
+- **Start at 0.5 A.** If the homing move triggers the endstop before reaching the hard stop (false trigger during free motion), increase in steps of 0.1–0.25 A until false triggers stop.
+- **Do not set it to `run_current`.** At full rated current the motor pushes hard into the hard stop before stopping, stressing the frame and endstop unnecessarily.
+- A typical working range for NEMA-17 steppers at homing speeds up to 100 mm/s is **0.5–1.5 A.** Heavier carriages or faster homing speeds require more.
+
+To measure the actual free-motion demand: home the axis without touching the hard stop, then immediately run `TMC_DEBUG_CURRENT` and read the `IQ actual` value. Set `homing_current` to approximately 1.5× that value.
+
+### homing_retract_dist must not be zero
+
+If `homing_retract_dist: 0`, the carriage stays at the hard stop after the first homing pass. On the next G28 the STATUS pin is already high (stall flags are still set from the previous contact), so there is no rising edge for the MCU endstop to detect and the second pass will not stop on contact. Set `homing_retract_dist` to at least 3–5 mm.
+
+### Homing mask (advanced)
+
+The set of STATUS_FLAGS bits that activate the STATUS pin is configurable via `homing_mask`. The default is suitable for most installations:
+
+```ini
+homing_mask: PID_IQ_OUTPUT_LIMIT, PID_ID_OUTPUT_LIMIT, PID_X_ERRSUM_LIMIT,
+             PID_IQ_TARGET_LIMIT, PID_ID_TARGET_LIMIT, PID_V_OUTPUT_LIMIT,
+             REF_SW_R, REF_SW_L
+```
+
+`PID_IQ_TARGET_LIMIT` is the primary fast-acting stall flag. `REF_SW_R` and `REF_SW_L` allow physical limit switches to be wired to the driver board's reference switch inputs and used as endstops without an additional MCU GPIO. Most users should not need to change this.
 
 ## G-code command reference
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ spi_bus: spi1
 spi_speed: 1000000
 current_scale_ma_lsb: 1.155
 adc_temp_reg: AGPI_B
-#diag_pin: ^MCU_DIAG_PIN   # sensorless homing: MCU GPIO connected to driver STATUS output
+#diag_pin: ^tmcx:PE8       # sensorless homing: OpenFFBoard STATUS output pin
 #homing_current: 0.5       # sensorless homing: start here, increase if false triggers (see Sensorless homing section)
 run_current: 3.54
 flux_current: 0.0
@@ -198,8 +198,9 @@ homing_retract_dist: 5
 In `[tmc4671 stepper_x]`, add the diag pin and homing current:
 
 ```ini
-diag_pin: ^MCU_DIAG_PIN   # MCU GPIO connected to the STATUS output; ^ if open-drain
-homing_current: 0.5       # starting point — tune as described below
+diag_pin: ^tmcx:PE8        # OpenFFBoard STATUS output pin; ^ for pull-up
+#diag_pin: ^MCU_DIAG_PIN  # other hardware: MCU GPIO connected to STATUS output
+homing_current: 0.5        # starting point — tune as described below
 ```
 
 ### Tuning homing_current

--- a/docs/sensorless-homing-options.md
+++ b/docs/sensorless-homing-options.md
@@ -1,0 +1,122 @@
+# Sensorless homing options for TMC4671
+
+`TMCVirtualPinHelper` exposes a `virtual_endstop` pin. Its mechanism:
+`STATUS_FLAGS & STATUS_MASK` drives the TMC4671's STATUS output pin → `diag_pin` GPIO on the MCU → Klipper polls it as an endstop.
+
+The signalling path (STATUS pin → MCU → Klipper) works. The problem is that the STATUS_FLAGS bits currently in the homing mask do not fire reliably when the motor hits a hard mechanical stop.
+
+## Why the current mask fails
+
+When the motor stalls in position mode:
+
+1. Step pulses keep advancing the position target
+2. Position error grows → position PID drives velocity target up to `PID_VELOCITY_LIMIT`
+3. Velocity error = velocity_target − 0 → velocity PID I-term drives torque target upward
+4. Torque target is clamped by `PID_TORQUE_FLUX_LIMITS` (= run_current = 3.54 A)
+5. At standstill, 3.54 A only needs V = R × I ≈ 1.14 × 3.54 ≈ **4 V**, far below the PIDOUT_UQ_UD_LIMITS of 31440/32767 × 24 V ≈ **23 V**
+
+`PID_IQ_OUTPUT_LIMIT` and `PID_ID_OUTPUT_LIMIT` — the two primary bits in the current mask — only fire when UQ/UD hits PIDOUT_UQ_UD_LIMITS (23 V). A stalled motor at the current limit needs only 4 V. **They never fire.**
+
+`PID_V_OUTPUT_LIMIT` does eventually fire, but only after the velocity I-term accumulates enough to saturate the torque target. With `foc_pid_velocity_i = 0.0188` and a velocity error of ~47253 counts/s, detection takes **3–4 seconds**. That is too slow for practical homing.
+
+`PID_X_OUTPUT_LIMIT` (bit 3) — the position PID output limit — is **not in the current mask at all**, and would fire faster than the velocity output limit.
+
+There is no dedicated "stall" register or flag in the TMC4671; there is no StallGuard equivalent.
+
+## Options
+
+### Option A — Tighten PIDOUT_UQ_UD_LIMITS during homing (most reliable, fastest)
+
+The voltage a free-moving motor needs at homing speed is approximately
+`V_free ≈ R × I_homing + Kt × ω`. At slow homing speeds back-EMF is negligible,
+so `V_free ≈ R × I_homing`. Set PIDOUT_UQ_UD_LIMITS to just above `V_free`:
+
+```
+limit = round((R * I_homing * safety_factor) / VM * 32767)
+# e.g. R=1.14, I=1A, VM=24V, factor=1.5 → round(1.14*1*1.5/24*32767) ≈ 2333
+```
+
+At stall UQ immediately tries to maintain current but the voltage limit clamps it →
+`IPARK_CIRLIM_LIMIT_U_Q` (bit 17) fires within microseconds. Restore normal limits
+in `handle_homing_move_end`.
+
+Add `IPARK_CIRLIM_LIMIT_U_Q` and `IPARK_CIRLIM_LIMIT_U_D` (bits 16–17) to the
+homing mask.
+
+The `safety_factor` needs tuning: too tight → false trigger during free movement;
+too loose → slow detection.
+
+### Option B — Reduce PID_VELOCITY_LIMIT + add PID_X_OUTPUT_LIMIT to mask
+
+There is already a commented-out line in `handle_homing_move_begin` (tmc4671.py line ~707):
+
+```python
+#self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
+```
+
+`PID_X_OUTPUT_LIMIT` (bit 3) fires when the position PID output (velocity target) hits
+`PID_VELOCITY_LIMIT`. Position error needed = `PID_VELOCITY_LIMIT / P_position`.
+With P = 15.7:
+
+| PID_VELOCITY_LIMIT | Error needed | Motor rotation |
+|---|---|---|
+| 47253 (current) | 3010 counts | ~270° — far too much |
+| 3000 | 191 counts | ~17° — still large |
+| 500 | 32 counts | ~3° / ~0.1 mm — usable |
+
+Constraint: PID_VELOCITY_LIMIT must be ≥ the velocity commanded during homing, or the
+motor cannot track the step pulses during free movement. The correct value depends on
+homing speed in TMC4671 velocity units. Option A avoids this dependency.
+
+Also add `PID_X_OUTPUT_LIMIT` to `homing_mask` (it is currently absent).
+
+### Option C — Add PID_IQ_TARGET_LIMIT to mask (slow but trivial)
+
+`PID_IQ_TARGET_LIMIT` (bit 12) fires when the velocity I-term drives the torque target
+above the current limit. Add this bit to `homing_mask` in the config. Detection still
+takes several seconds, but it will eventually fire. Reasonable fallback if nothing else
+is working yet — requires no code change, only a config line:
+
+```ini
+homing_mask: PID_IQ_TARGET_LIMIT, PID_V_OUTPUT_LIMIT, PID_X_ERRSUM_LIMIT, PID_ID_TARGET_LIMIT, REF_SW_R, REF_SW_L
+```
+
+### Option D — Velocity mode homing (most reliable long-term)
+
+Position mode is the wrong mode for sensorless homing. In velocity mode:
+
+- Command a small constant velocity target directly to `PID_VELOCITY_TARGET`
+- Motor moves at that velocity; at stall, actual velocity drops to zero
+- Velocity error = constant `velocity_target` → `PID_V_ERRSUM_LIMIT` fires quickly
+  (the I-term saturates proportionally to velocity_target, not accumulated position error)
+- Detection time is predictable and tunable
+
+This requires a custom `TMC_HOME STEPPER=x DIRECTION=+ SPEED=5` G-code command that:
+
+1. Switches to velocity mode
+2. Commands the appropriate velocity
+3. Waits for STATUS_FLAGS (with `PID_V_ERRSUM_LIMIT` in mask) or timeout
+4. Switches back to position mode, resets position
+
+This bypasses standard G28/step-pulse homing but integrates cleanly with Klipper's
+macro system via `[homing_override]`.
+
+### Option E — Software position-deviation polling
+
+Read `PID_ERROR_PID_POSITION_ERROR` (register 0x6C, addr=3) via SPI every 20ms from a
+reactor callback during homing. If deviation exceeds a threshold, stop the move.
+The problem is that there is no clean way to inject a stop into Klipper's trsync from
+the host side without MCU cooperation. Complex; not recommended.
+
+## Recommended path
+
+**Immediate diagnostic**: `handle_homing_move_end` already logs STATUS_FLAGS. Check
+which bits (if any) were set when the motor hit the stop.
+
+**Practical fix**: **Option A** — tighten PIDOUT_UQ_UD_LIMITS during homing and add
+`IPARK_CIRLIM_LIMIT_U_Q`/`U_D` to the homing mask. This converts stall detection from
+"wait N seconds for PID integration" to "immediate voltage saturation." The limit value
+is directly calculable from measured R, homing current, and VM.
+
+**Long-term**: **Option D** — velocity-mode `TMC_HOME` command. Most reliable
+architecture and the best fit for what the hardware does naturally.

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -702,10 +702,8 @@ class TMCVirtualPinHelper:
         self.mcu_endstop = ppins.setup_pin('endstop', self.diag_pin)
         return self.mcu_endstop
     def handle_homing_move_begin(self, hmove):
-        if self.mcu_endstop not in hmove.get_mcu_endstops():
-            return
-        #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
-        self.current_helper.set_current(self.current_helper.get_homing_current())
+        # Always observe: set STATUS_MASK and log flags for any homing move on this axis.
+        # Homing current change is only applied when this is the active (virtual) endstop.
         self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
         self.printer.lookup_object('toolhead').dwell(0.005)
         self.mcu_tmc.write_field("STATUS_MASK", self.status_mask)
@@ -713,17 +711,22 @@ class TMCVirtualPinHelper:
         status = self.mcu_tmc.get_register("STATUS_FLAGS")
         fmt = self.fields.pretty_format("STATUS_FLAGS", status)
         logging.info("TMC 4671 '%s' status at homing start %s", self.name, fmt)
+        if self.mcu_endstop not in hmove.get_mcu_endstops():
+            return
+        #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
+        self.current_helper.set_current(self.current_helper.get_homing_current())
     def handle_homing_move_end(self, hmove):
         status = self.mcu_tmc.get_register("STATUS_FLAGS")
         fmt = self.fields.pretty_format("STATUS_FLAGS", status)
         logging.info("TMC 4671 '%s' status at homing end %s", self.name, fmt)
+        # Always: clear STATUS_MASK after any homing move on this axis.
+        self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
+        self.mcu_tmc.write_field("STATUS_MASK", 0)
+        self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
         #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 0x300000)
-        self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
         self.current_helper.set_current(self.current_helper.get_run_current())
-        self.mcu_tmc.write_field("STATUS_MASK", 0)
-        self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
 
 
 ######################################################################

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -685,8 +685,11 @@ class TMCVirtualPinHelper:
         logging.info("TMC virtual endstop %s, mask is %x", self.name, self.status_mask)
         ppins = self.printer.lookup_object("pins")
         ppins.register_chip("%s" % (self.name), self)
+        self.printer.register_event_handler("homing:homing_move_begin",
+                                            self.handle_homing_move_begin)
+        self.printer.register_event_handler("homing:homing_move_end",
+                                            self.handle_homing_move_end)
     def setup_pin(self, pin_type, pin_params):
-        # Validate pin
         ppins = self.printer.lookup_object('pins')
         if pin_type != 'endstop' or pin_params['pin'] != 'virtual_endstop':
             raise ppins.error("tmc virtual endstop only useful as endstop")
@@ -694,11 +697,6 @@ class TMCVirtualPinHelper:
             raise ppins.error("Can not pullup/invert tmc virtual pin")
         if self.diag_pin is None:
             raise ppins.error("tmc virtual endstop requires diag pin config")
-        # Setup for sensorless homing
-        self.printer.register_event_handler("homing:homing_move_begin",
-                                            self.handle_homing_move_begin)
-        self.printer.register_event_handler("homing:homing_move_end",
-                                            self.handle_homing_move_end)
         self.mcu_endstop = ppins.setup_pin('endstop', self.diag_pin)
         return self.mcu_endstop
     def handle_homing_move_begin(self, hmove):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -668,7 +668,7 @@ class TMCVirtualPinHelper:
                                                    "PID_X_ERRSUM_LIMIT",
                                                    #"PID_IQ_ERRSUM_LIMIT",
                                                    #"PID_ID_ERRSUM_LIMIT",
-                                                   #"PID_IQ_TARGET_LIMIT",
+                                                   "PID_IQ_TARGET_LIMIT",
                                                    "PID_ID_TARGET_LIMIT",
                                                    #"PID_X_OUTPUT_LIMIT",
                                                    "PID_V_OUTPUT_LIMIT",


### PR DESCRIPTION
Implements and documents sensorless homing via the TMC 4671 STATUS output pin.

## Changes

- **Observe STATUS_FLAGS during all homing moves**, not only when the virtual endstop is the active endstop — useful for logging even when a physical endstop is in use
- **Register homing event handlers unconditionally** in `__init__` rather than only when `setup_pin` is called, so handlers fire even without a `diag_pin` configured
- **Add `PID_IQ_TARGET_LIMIT` to the default homing mask** — this flag fires within a few PWM cycles (~40 µs) of contact via the velocity PID P-term, far faster than `PID_V_OUTPUT_LIMIT` which requires integrator wind-up over hundreds of milliseconds
- **Document sensorless homing** in README: hardware wiring, config, `homing_current` tuning guide (start at 0.5 A, increase if false triggers), and the `homing_retract_dist ≠ 0` requirement
- **Update config example** to show both physical and sensorless endstop options side-by-side with one commented out

## Root cause of previous non-working state

The STATUS pin was only gated on `PID_V_OUTPUT_LIMIT`, which requires the velocity PID I-term to wind up to saturation — potentially hundreds of milliseconds of grinding into the hard stop. `PID_IQ_TARGET_LIMIT` fires from the P-term alone, making stall detection essentially instantaneous.