### PR TITLE
Fix sensorless homing current corruption after first home

### DIFF
--- a/tmc4671.py
+++ b/tmc4671.py
@@ -474,6 +474,10 @@ class CurrentHelper:
         self.flux_limit = self._calc_flux_limit(self.run_current)
         self._write_field("PID_TORQUE_FLUX_LIMITS", self.flux_limit)
         return self.flux_limit
+    def apply_current_limit(self, current):
+        flux_limit = self._calc_flux_limit(current)
+        self._write_field("PID_TORQUE_FLUX_LIMITS", flux_limit)
+        return flux_limit
     def set_flux_current(self, current):
         self.flux_current = current
         self.flux_limit = self._calc_flux_limit(self.flux_current)
@@ -712,7 +716,7 @@ class TMCVirtualPinHelper:
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
         #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
-        self.current_helper.set_current(self.current_helper.get_homing_current())
+        self.current_helper.apply_current_limit(self.current_helper.get_homing_current())
     def handle_homing_move_end(self, hmove):
         status = self.mcu_tmc.get_register("STATUS_FLAGS")
         fmt = self.fields.pretty_format("STATUS_FLAGS", status)
@@ -724,7 +728,7 @@ class TMCVirtualPinHelper:
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
         #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 0x300000)
-        self.current_helper.set_current(self.current_helper.get_run_current())
+        self.current_helper.apply_current_limit(self.current_helper.get_run_current())
 
 
 ######################################################################


### PR DESCRIPTION
## Problem

After the first successful G28, sensorless homing fails on any subsequent G28 following a motor disable/re-enable (M84 or idle timeout).

### Root cause

\`CurrentHelper.set_current()\` was being called from both homing event handlers to switch between homing and run current. This method unconditionally overwrites \`self.run_current\`:

\`\`\`python
def set_current(self, run_current):
    self.run_current = run_current  # corrupts stored value!
    ...
\`\`\`

After \`handle_homing_move_begin\` calls \`set_current(get_homing_current())\`, \`self.run_current\` is set to e.g. 1.0 A. Then \`handle_homing_move_end\` calls \`set_current(get_run_current())\`, which returns the now-corrupted 1.0 A — so the restore is a no-op and the configured run_current (e.g. 3.54 A) is permanently lost.

### Failure chain after disable/re-enable

With run_current silently reduced to 1.0 A, the motor operates at homing current all the time. Any position disturbance after re-enable causes \`PID_IQ_TARGET_LIMIT\` to fire and stick in STATUS_FLAGS. When the next G28 starts, \`handle_homing_move_begin\` clears STATUS_FLAGS then writes STATUS_MASK — but the chip immediately re-asserts the flag because the motor is still saturating at 1.0 A. The STATUS pin stays permanently HIGH before trsync arms. Since the diag_pin endstop is edge-triggered, no rising edge occurs at the actual hard stop, so homing never terminates on contact (trsync reason=2, host abort).

A soft restart fixes it because the new \`CurrentHelper\` object re-reads run_current from config.

## Fix

Add \`apply_current_limit(current)\` to \`CurrentHelper\` — identical hardware effect to \`set_current\` but does **not** update \`self.run_current\`. Use it from both homing event handlers.

\`set_current()\` remains correct for \`TMC_SET_CURRENT\` which intentionally updates the stored run_current.