### PR TITLE
Fix sensorless homing false trigger from velocity PID saturation during acceleration

### DIFF
--- a/tmc4671.py
+++ b/tmc4671.py
@@ -474,6 +474,10 @@ class CurrentHelper:
         self.flux_limit = self._calc_flux_limit(self.run_current)
         self._write_field("PID_TORQUE_FLUX_LIMITS", self.flux_limit)
         return self.flux_limit
+    def apply_current_limit(self, current):
+        flux_limit = self._calc_flux_limit(current)
+        self._write_field("PID_TORQUE_FLUX_LIMITS", flux_limit)
+        return flux_limit
     def set_flux_current(self, current):
         self.flux_current = current
         self.flux_limit = self._calc_flux_limit(self.flux_current)
@@ -712,7 +716,7 @@ class TMCVirtualPinHelper:
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
         #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
-        self.current_helper.set_current(self.current_helper.get_homing_current())
+        self.current_helper.apply_current_limit(self.current_helper.get_homing_current())
     def handle_homing_move_end(self, hmove):
         status = self.mcu_tmc.get_register("STATUS_FLAGS")
         fmt = self.fields.pretty_format("STATUS_FLAGS", status)
@@ -724,7 +728,7 @@ class TMCVirtualPinHelper:
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
         #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 0x300000)
-        self.current_helper.set_current(self.current_helper.get_run_current())
+        self.current_helper.apply_current_limit(self.current_helper.get_run_current())
 
 
 ######################################################################

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -663,9 +663,14 @@ class TMCVirtualPinHelper:
         self.diag_pin = config.get('diag_pin', None)
         self.mcu_endstop = None
         self.en_pwm = False
-        # Stalls show up as either IQ_ERRSUM or V_OUTPUT.
-        # Include the reference switches so can connect endstops
-        # to driver boards.
+        self._saved_velocity_limit = 0x10000000
+        # PID_V_OUTPUT_LIMIT fires during position-mode homing acceleration
+        # (position PID immediately saturates on large position error, velocity
+        # I-term winds up before the motor reaches the hard stop), causing false
+        # triggers.  PID_IQ_TARGET_LIMIT is the reliable indicator: we set
+        # PID_VELOCITY_LIMIT to 0x7FFFFFFF during the homing move so the
+        # velocity PID output can grow until it exceeds PID_TORQUE_FLUX_LIMITS
+        # (homing current limit), firing within ~1 PWM cycle at true stall.
         self.status_mask_entries = config.getlist("homing_mask",
                                                   ["PID_IQ_OUTPUT_LIMIT",
                                                    "PID_ID_OUTPUT_LIMIT",
@@ -675,7 +680,7 @@ class TMCVirtualPinHelper:
                                                    "PID_IQ_TARGET_LIMIT",
                                                    "PID_ID_TARGET_LIMIT",
                                                    #"PID_X_OUTPUT_LIMIT",
-                                                   "PID_V_OUTPUT_LIMIT",
+                                                   #"PID_V_OUTPUT_LIMIT",
                                                    "REF_SW_R",
                                                    "REF_SW_L"])
         self.status_mask = 0
@@ -715,7 +720,8 @@ class TMCVirtualPinHelper:
         logging.info("TMC 4671 '%s' status at homing start %s", self.name, fmt)
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
-        #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 3000)
+        self._saved_velocity_limit = self.mcu_tmc.get_register("PID_VELOCITY_LIMIT")
+        self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 0x7fffffff)
         self.current_helper.apply_current_limit(self.current_helper.get_homing_current())
     def handle_homing_move_end(self, hmove):
         status = self.mcu_tmc.get_register("STATUS_FLAGS")
@@ -727,7 +733,7 @@ class TMCVirtualPinHelper:
         self.mcu_tmc.set_register_once("STATUS_FLAGS", 0)
         if self.mcu_endstop not in hmove.get_mcu_endstops():
             return
-        #self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", 0x300000)
+        self.mcu_tmc.write_field("PID_VELOCITY_LIMIT", self._saved_velocity_limit)
         self.current_helper.apply_current_limit(self.current_helper.get_run_current())
 
 


### PR DESCRIPTION
## Problem

After deploying the homing current corruption fix (PR #23), homing still failed with "No trigger on x after full movement".

Log analysis showed two root causes:

**1. Premature trigger from PID_V_OUTPUT_LIMIT**

In position-mode homing at 100 mm/s, the position target jumps far ahead of the motor (large position error → position PID immediately saturates, `pid_x_output_limit` fires before the move begins). With position PID saturated, the velocity PID sees a large velocity error during the acceleration phase and its I-term integrates up until `pid_v_output_limit` fires — while the motor is still moving freely, not at the physical hard stop.

Result: Klipper sets X=350 when the motor is physically at ~320. The re-probe (attempt 2) then starts from virtual X=350, moves a few mm in the same direction, the motor travels freely with no stall flags, and "No trigger on x after full movement" is raised.

**2. PID_IQ_TARGET_LIMIT never fires**

`PID_VELOCITY_LIMIT` (the velocity PID output clamp) is smaller than `PID_TORQUE_FLUX_LIMITS` (homing current limit in the same LSB units). The velocity PID output is clamped before it can reach the torque/flux limit threshold, so `pid_iq_target_limit` never fires.

## Fix

- Remove `PID_V_OUTPUT_LIMIT` from the default `homing_mask` (false triggers during acceleration).
- In `handle_homing_move_begin`, save the current `PID_VELOCITY_LIMIT` and write `0x7FFFFFFF` — removing the velocity output clamp so the velocity PID can grow until it exceeds `PID_TORQUE_FLUX_LIMITS` (the homing current limit).
- In `handle_homing_move_end`, restore `PID_VELOCITY_LIMIT`.

At true stall, the velocity PID output grows until it hits the homing current limit → `pid_iq_target_limit` fires within ~1 PWM cycle (~40 µs). During normal homing motion at constant speed, the velocity error is small and the demand stays well below 1 A.

## Depends on
PR #23 (apply_current_limit fix)