### PR TITLE
Add inertia ratio measurement at startup calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,13 +402,14 @@ Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, i
 **Before running:** position the toolhead so the axis under test can move approximately 5 mm in both directions without hitting an endstop or physical obstruction.
 
 ```
-TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.05] [CURRENT=<amps>]
+TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.05] [SETTLE_DURATION=1.0] [CURRENT=<amps>]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
 | `STEPPER` | — | Stepper name to measure (required) |
 | `PULSE_DURATION` | 0.05 | Duration of each accel and brake phase in seconds (0.01–2.0). Increase if displacement is too small (high stiction). |
+| `SETTLE_DURATION` | 1.0 | Settle time between pulse pairs in seconds (0.1–5.0). Increase if readings are inconsistent (motor still moving between pulses). |
 | `CURRENT` | run_current / 2 | Test current in amps. Increase for high-stiction machines. Must not exceed run_current. |
 
 The command:

--- a/README.md
+++ b/README.md
@@ -402,10 +402,16 @@ Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, i
 **Before running:** position the toolhead so the axis under test can move approximately 5 mm in both directions without hitting an endstop or physical obstruction.
 
 ```
-TMC_MEASURE_INERTIA STEPPER=stepper_x
+TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.2] [CURRENT=<amps>]
 ```
 
-No parameters. The command:
+| Parameter | Default | Description |
+|---|---|---|
+| `STEPPER` | — | Stepper name to measure (required) |
+| `PULSE_DURATION` | 0.2 | Duration of each accel and brake phase in seconds (0.05–2.0). Increase if displacement is too small (high stiction). |
+| `CURRENT` | run_current / 2 | Test current in amps. Increase for high-stiction machines. Must not exceed run_current. |
+
+The command:
 
 1. De-energises all other TMC4671 axes (stopped mode, gate driver off).
 2. Aligns the target rotor to PHI_E = 0 at half run-current.

--- a/README.md
+++ b/README.md
@@ -395,6 +395,26 @@ TMC_MEASURE_IMPEDANCE STEPPER=stepper_x [F_INJECT=<hz>] [N_SAMPLES=<int>]
 
 The command applies a rotating AC voltage vector on top of the measured motor winding resistance (using the motor resistance measured during startup alignment) and accumulates raw d/q current readings stochastically to extract distinct admittances, converting them to Ld and Lq inductances. Requires prior startup alignment.
 
+### TMC_MEASURE_INERTIA
+
+Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, in rad s⁻² A⁻¹) using a 4-pulse accel+brake cycle in open-loop UQ/UD-EXT mode. All other TMC4671 axes are de-energised during the measurement to eliminate CoreXY magnetic coupling.
+
+**Before running:** position the toolhead so the axis under test can move approximately 5 mm in both directions without hitting an endstop or physical obstruction.
+
+```
+TMC_MEASURE_INERTIA STEPPER=stepper_x
+```
+
+No parameters. The command:
+
+1. De-energises all other TMC4671 axes (stopped mode, gate driver off).
+2. Aligns the target rotor to PHI_E = 0 at half run-current.
+3. Runs four accel+brake pulse pairs (forward × 2, reverse × 2) and reads encoder displacement after each.
+4. Computes `Kt/J = d × 2π / (PPR × Iq × dt²)` and stores the result in `motor_jt`.
+5. Restores all other axes to their normal idle state.
+
+The result is reported immediately and also shown in `TMC_DEBUG_MOTOR`. Requires prior startup alignment (motor_r must be non-zero). The measurement adds approximately 2.8 s to the command runtime.
+
 ### TMC_DEBUG_MOTOR
 
 Report the motor resistance, average inductance, estimated Ld inductance, estimated Lq inductance, and spatial saliency ratio measured during the last startup alignment (or manual `TMC_MEASURE_IMPEDANCE` run).

--- a/README.md
+++ b/README.md
@@ -397,28 +397,29 @@ The command applies a rotating AC voltage vector on top of the measured motor wi
 
 ### TMC_MEASURE_INERTIA
 
-Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, in rad s⁻² A⁻¹) using a 4-pulse accel+brake cycle in open-loop UQ/UD-EXT mode. All other TMC4671 axes are de-energised during the measurement to eliminate CoreXY magnetic coupling.
+Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, in rad s⁻² A⁻¹) using closed-loop torque-mode pulses. The command automatically selects a test current low enough that the motor coasts to rest before the next pulse, using successive approximation starting from 20 mA. All other TMC4671 axes are de-energised during the measurement to eliminate CoreXY magnetic coupling.
 
 **Before running:** position the toolhead so the axis under test can move approximately 5 mm in both directions without hitting an endstop or physical obstruction.
 
 ```
-TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.05] [SETTLE_DURATION=1.0] [CURRENT=<amps>]
+TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.05] [SETTLE_DURATION=1.0] [MAX_CURRENT=<amps>]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
 | `STEPPER` | — | Stepper name to measure (required) |
-| `PULSE_DURATION` | 0.05 | Duration of each accel and brake phase in seconds (0.01–2.0). Increase if displacement is too small (high stiction). |
-| `SETTLE_DURATION` | 1.0 | Settle time between pulse pairs in seconds (0.1–5.0). Increase if readings are inconsistent (motor still moving between pulses). |
-| `CURRENT` | run_current / 2 | Test current in amps. Increase for high-stiction machines. Must not exceed run_current. |
+| `PULSE_DURATION` | 0.05 | Duration of each torque pulse in seconds (0.01–2.0). Increase if displacement is too small (high stiction). |
+| `SETTLE_DURATION` | 1.0 | Settle time after each pulse in seconds (0.1–5.0). Increase if readings are inconsistent (motor still moving between pulses). |
+| `MAX_CURRENT` | run_current / 2 | Upper bound on test current in amps. The command auto-scales downward from this limit. Must not exceed run_current. |
 
 The command:
 
 1. De-energises all other TMC4671 axes (stopped mode, gate driver off).
 2. Aligns the target rotor to PHI_E = 0 at half run-current.
-3. Runs four accel+brake pulse pairs (forward × 2, reverse × 2) and reads encoder displacement after each.
-4. Computes `Kt/J = d × 2π / (PPR × Iq × dt²)` and stores the result in `motor_jt`.
-5. Restores all other axes to their normal idle state.
+3. Searches for a test current that produces ~1/8 revolution displacement per pulse (successive approximation, starting at 20 mA).
+4. Runs four pulse pairs (forward × 2, reverse × 2) and reads encoder displacement after each.
+5. Computes `Kt/J = d × 4π / (PPR × Iq × dt²)` and stores the result in `motor_jt`.
+6. Restores all other axes to their normal idle state.
 
 The result is reported immediately and also shown in `TMC_DEBUG_MOTOR`. Requires prior startup alignment (motor_r must be non-zero). The measurement adds approximately 2.8 s to the command runtime.
 

--- a/README.md
+++ b/README.md
@@ -402,13 +402,13 @@ Measure the Kt/J ratio (motor torque constant divided by rotor + load inertia, i
 **Before running:** position the toolhead so the axis under test can move approximately 5 mm in both directions without hitting an endstop or physical obstruction.
 
 ```
-TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.2] [CURRENT=<amps>]
+TMC_MEASURE_INERTIA STEPPER=stepper_x [PULSE_DURATION=0.05] [CURRENT=<amps>]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
 | `STEPPER` | — | Stepper name to measure (required) |
-| `PULSE_DURATION` | 0.2 | Duration of each accel and brake phase in seconds (0.05–2.0). Increase if displacement is too small (high stiction). |
+| `PULSE_DURATION` | 0.05 | Duration of each accel and brake phase in seconds (0.01–2.0). Increase if displacement is too small (high stiction). |
 | `CURRENT` | run_current / 2 | Test current in amps. Increase for high-stiction machines. Must not exceed run_current. |
 
 The command:

--- a/docs/inertia-measurement-status.md
+++ b/docs/inertia-measurement-status.md
@@ -1,0 +1,55 @@
+# Inertia measurement — status and open problems
+
+Branch: `measure-inertia-ratio` (not merged to main as of June 2026).
+
+## What was implemented
+
+`TMC_MEASURE_INERTIA STEPPER=<name>` measures the Kt/J ratio (motor torque constant divided by effective rotor + load inertia, in rad s⁻² A⁻¹). The value is stored in `motor_jt` and shown by `TMC_DEBUG_MOTOR`.
+
+### Method
+
+1. All other TMC4671 axes are de-energised (stopped mode, TMC6100 gate driver disabled) to break the CoreXY magnetic coupling.
+2. The target motor is aligned to PHI_E = 0 in UQ/UD-EXT mode (d-axis hold at half run-current) with a 0.75 s dwell.
+3. **Successive approximation** (new as of `4799a8f`): starting at 20 mA, the current is scaled proportionally toward `ppr // 8` counts (one-eighth revolution ≈ 45°) of displacement per pulse, converging in ~2–3 iterations.
+4. The found current is used for a **4-pulse measurement** in closed-loop torque mode (PHI_E_SELECTION = 3, torque_mode): forward × 2, reverse × 2, each = torque pulse for `dt` + zero torque coast-to-stop for `settle`.
+5. The second pulse in each direction is used for the Kt/J calculation (first pulse absorbs backlash).
+6. Formula: `alpha = d_avg × 4π / (PPR × dt²)`, `motor_jt = alpha / Iq_A` (coast-to-stop overshoot means this is a slight upper bound on the true value).
+7. All other axes are restored (PWM_CHOP = 7, gate driver re-enabled). Motors need M17 to resume position mode.
+
+### Parameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `PULSE_DURATION` | 0.05 s | Accel phase duration |
+| `SETTLE_DURATION` | 1.0 s | Coast-to-stop wait |
+| `MAX_CURRENT` | run_current / 2 | Upper bound for the current search |
+
+## Known problems / open work
+
+### Kt/J is very high on this hardware
+
+The measured value on the CoreXY at v24p4 is approximately **1800 rad s⁻² A⁻¹**. This is a linear-rail machine with very low friction, so the effective J is small.
+
+Consequence: even at the auto-selected "small" current, the motor can reach significant angular velocity within `dt = 0.05 s`:
+- v_peak = Kt/J × Iq × dt = 1800 × Iq × 0.05
+
+For the motor to coast to rest within `settle = 1.0 s`, friction must decelerate it from v_peak. On low-friction rails this may require many seconds. The successive approximation targets `ppr // 8` displacement (≈ 45°), which for Kt/J = 1800 corresponds to:
+- d = ½ × alpha × dt² = ½ × 1800 × Iq × 0.05² = 2.25 × Iq (in rad, then × PPR/2π for counts)
+- At PPR = 4000: target_counts = 500 → Iq ≈ 2.25 × Iq × 4000/(2π) ... solving: Iq = 500 × 2π / (4000 × 2.25) ≈ 0.175 A
+- v_peak = 1800 × 0.175 × 0.05 = 15.75 rad/s ≈ 150 RPM
+
+Stopping from 150 RPM against viscous friction alone can take 3–10 s on smooth linear rails, well beyond the 1 s settle. The measurement still works in practice if `SETTLE_DURATION` is increased, but the default is too short for low-friction machines.
+
+### Possible fixes
+
+**A — Adaptive settle**: after zeroing torque, poll `ABN_DECODER_COUNT` repeatedly until it stops changing. No hardware velocity register exists (`ABN_DECODER_VELOCITY` is not in the register map), so this must be done by reading the position twice with a short gap and checking for drift. Adds SPI traffic but avoids needing a large fixed settle time.
+
+**B — Braking phase**: re-introduce the braking phase that was in `b411b08` before `4cb6441` removed it. Apply −Iq for `dt` after the accel pulse. The motor decelerates predictably and stops within `dt` seconds. Settle time can then be reduced to ~2× dt. The formula uses `d_mid` (displacement at mid-point = end of accel phase only), which gives an exact result with no coast contribution. This is the most reliable approach.
+
+**C — Reduce `dt`**: shrink the pulse duration so v_peak is smaller. At dt = 0.01 s: v_peak = 1800 × 0.175 × 0.01 = 3.15 rad/s — would settle in 1 s even on smooth rails. Displacement = 500 × (0.01/0.05)² = 20 counts, which may be too small for reliable counting (encoder noise, quantisation).
+
+**D — Velocity feedback target**: instead of a fixed pulse duration, apply torque until a target v_peak is reached (e.g., 5 rad/s), then zero torque. Requires reading a velocity estimate, which the TMC4671 provides indirectly via differencing `ABN_DECODER_COUNT` reads.
+
+### Recommendation
+
+Option B (restore braking phase) is the cleanest long-term solution. It eliminates the settle-time problem entirely, gives a physically exact formula, and is robust across a wide range of Kt/J values and friction levels. The additional complexity (one extra dwell + mid-point encoder read) is modest.

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -885,6 +885,10 @@ class MCU_TMC_SPI:
 # Main driver class
 ######################################################################
 
+# All live TMC4671 instances — used by TMC_MEASURE_INERTIA to mute
+# other axes while measuring one axis at a time.
+_all_tmc4671s = []
+
 
 class TMC4671:
     def __init__(self, config):
@@ -893,6 +897,7 @@ class TMC4671:
         self.name = config.get_name().split()[-1]
         self.mutex = self.printer.get_reactor().mutex()
         self.init_done = False
+        _all_tmc4671s.append(self)
         self.alignment_done = False
         self.fields = FieldHelper(Fields,
                                   signed_fields=SignedFields,
@@ -1010,6 +1015,13 @@ class TMC4671:
             self.name,
             self.cmd_TMC_MEASURE_IMPEDANCE,
             desc=self.cmd_TMC_MEASURE_IMPEDANCE_help,
+        )
+        gcode.register_mux_command(
+            "TMC_MEASURE_INERTIA",
+            "STEPPER",
+            self.name,
+            self.cmd_TMC_MEASURE_INERTIA,
+            desc=self.cmd_TMC_MEASURE_INERTIA_help,
         )
         # Allow other registers to be set from the config
         set_config_field = self.fields.set_config_field
@@ -1188,6 +1200,8 @@ class TMC4671:
         enable_line.register_state_callback(self._handle_stepper_enable)
 
     def _handle_disconnect(self):
+        if self in _all_tmc4671s:
+            _all_tmc4671s.remove(self)
         if self.fields6100 is not None:
             try:
                 self.mcu_tmc6100.set_register(
@@ -1678,6 +1692,78 @@ class TMC4671:
             "(PPR=%d, fwd=[%d,%d], bwd=[%d,%d])",
             self.stepper_name, self.motor_jt, backlash, ppr,
             d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2)
+
+    cmd_TMC_MEASURE_INERTIA_help = (
+        "Measure Kt/J inertia ratio on one axis; "
+        "position toolhead where it can move ~5 mm in both directions first"
+    )
+    def cmd_TMC_MEASURE_INERTIA(self, gcmd):
+        if self.motor_r < 1e-6:
+            raise gcmd.error(
+                "Motor resistance not calibrated. "
+                "Run startup calibration (FIRMWARE_RESTART) first.")
+        toolhead = self.printer.lookup_object('toolhead')
+        enable_line = self.stepper_enable.lookup_enable(self.stepper_name)
+        dwell = toolhead.dwell
+
+        others = [t for t in _all_tmc4671s if t is not self and t.init_done]
+        try:
+            for other in others:
+                with other.mutex:
+                    other.error_helper.stop_checks()
+                    other.fields.MODE_MOTION.write(MotionMode.stopped_mode)
+                    other.fields.PWM_CHOP.write(0)
+
+            with self.mutex:
+                print_time = toolhead.get_last_move_time()
+                old_phi_e_selection = self.fields.PHI_E_SELECTION.read()
+
+                if self.fields6100 is not None:
+                    self.mcu_tmc6100.set_register(
+                        "GCONF",
+                        self.fields6100.set_field("disable", 0),
+                        print_time)
+                enable_line.motor_enable(print_time)
+
+                try:
+                    vm = self._read_vm()
+                    target_a = self.current_helper.get_run_current() / 2.0
+                    align_u = min(
+                        round((target_a * self.motor_r / vm) * 32767.0),
+                        16383)
+                    align_u = max(align_u, 200)
+
+                    self.fields.MODE_MOTION.write(MotionMode.stopped_mode)
+                    self.fields.PHI_E_EXT.write(0)
+                    self.fields.PHI_E_SELECTION.write(1)
+                    self.fields.UQ_UD_EXT.write(align_u, 0)
+                    self._reset_targets()
+                    self.fields.MODE_MOTION.write(MotionMode.uq_ud_ext_mode)
+                    self.fields.PWM_CHOP.write(7)
+                    dwell(0.75)
+                    self.fields.ABN_DECODER_COUNT.write(0)
+
+                    self._measure_inertia_ratio(dwell, align_u, vm)
+                finally:
+                    self.fields.UQ_UD_EXT.write(0, 0)
+                    self.fields.MODE_MOTION.write(MotionMode.stopped_mode)
+                    self.fields.PHI_E_SELECTION.write(old_phi_e_selection)
+                    print_time = toolhead.get_last_move_time()
+                    enable_line.motor_disable(print_time)
+        finally:
+            for other in others:
+                with other.mutex:
+                    other.fields.PWM_CHOP.write(7)
+
+        if self.motor_jt == 0.0:
+            gcmd.respond_info(
+                "TMC 4671 '%s' inertia measurement failed or displacement too "
+                "small. Ensure the toolhead can move ~5 mm freely in both "
+                "directions, then re-run." % self.name)
+        else:
+            gcmd.respond_info(
+                "TMC 4671 '%s' Kt/J = %.2f rad/s\u00b2/A" % (
+                    self.name, self.motor_jt))
 
     # Tune PID via a setpoint change experiment
     # See https://folk.ntnu.no/skoge/publications/2012/skogestad-improved-simc-pid/PIDbook-chapter5.pdf

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1626,9 +1626,8 @@ class TMC4671:
         self._setup_filters()
 
     # Measure Kt/J ratio via 4-pulse accel+brake cycles in UQ/UD-EXT mode
-    def _measure_inertia_ratio(self, dwell, iq_test_u, vm):
-        dt = 0.2      # accel / brake phase duration [s]
-        settle = 0.3  # settling time between pulse pairs [s]
+    def _measure_inertia_ratio(self, dwell, iq_test_u, vm, dt=0.2):
+        settle = max(0.3, dt)  # settling time between pulse pairs [s]
 
         ppr = self.fields.ABN_DECODER_PPR.read()
         if ppr == 0:
@@ -1702,6 +1701,9 @@ class TMC4671:
             raise gcmd.error(
                 "Motor resistance not calibrated. "
                 "Run startup calibration (FIRMWARE_RESTART) first.")
+        pulse_duration = gcmd.get_float('PULSE_DURATION', 0.2,
+                                        minval=0.05, maxval=2.0)
+        current_override = gcmd.get_float('CURRENT', None, minval=0.1)
         toolhead = self.printer.lookup_object('toolhead')
         enable_line = self.stepper_enable.lookup_enable(self.stepper_name)
         dwell = toolhead.dwell
@@ -1732,7 +1734,9 @@ class TMC4671:
 
                 try:
                     vm = self._read_vm()
-                    target_a = self.current_helper.get_run_current() / 2.0
+                    target_a = (current_override
+                                if current_override is not None
+                                else self.current_helper.get_run_current() / 2.0)
                     align_u = min(
                         round((target_a * self.motor_r / vm) * 32767.0),
                         16383)
@@ -1748,7 +1752,8 @@ class TMC4671:
                     dwell(0.75)
                     self.fields.ABN_DECODER_COUNT.write(0)
 
-                    self._measure_inertia_ratio(dwell, align_u, vm)
+                    self._measure_inertia_ratio(dwell, align_u, vm,
+                                                dt=pulse_duration)
                 finally:
                     self.fields.UQ_UD_EXT.write(0, 0)
                     self.fields.MODE_MOTION.write(MotionMode.stopped_mode)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1621,9 +1621,11 @@ class TMC4671:
         # Re-enable the configured biquad filters
         self._setup_filters()
 
-    # Measure Kt/J ratio via 4-pulse accel+brake cycles in closed-loop torque mode
-    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.05, settle=1.0):
-        settle = max(settle, dt)  # settling time between pulse pairs [s]
+    # Measure Kt/J ratio via successive-approximation current search and
+    # 4-pulse closed-loop torque measurement.
+    def _measure_inertia_ratio(self, dwell, dt=0.05, settle=1.0,
+                               max_iq_lsbs=None):
+        settle = max(settle, dt)
 
         ppr = self.fields.ABN_DECODER_PPR.read()
         if ppr == 0:
@@ -1631,28 +1633,67 @@ class TMC4671:
                             self.stepper_name)
             return
 
-        if iq_lsbs == 0:
-            logging.warning("TMC 4671 '%s' inertia: test current is zero, skipping",
+        current_scale = self.current_helper.current_scale
+        if max_iq_lsbs is None:
+            max_iq_lsbs = round(
+                self.current_helper.get_run_current() * 500 / current_scale)
+        if max_iq_lsbs < 1:
+            logging.warning("TMC 4671 '%s' inertia: max current too small, skipping",
                             self.stepper_name)
             return
 
-        iq_a = iq_lsbs * self.current_helper.current_scale * 1e-3
-        if iq_a < 1e-6:
-            logging.warning("TMC 4671 '%s' inertia: computed IQ too small (%.4f A), skipping",
-                            self.stepper_name, iq_a)
-            return
+        # Target displacement: one-eighth revolution (~45°). Small enough to stay
+        # within the required free-movement range; large enough for reliable counting.
+        target_counts = max(ppr // 8, 10)
 
         # Closed-loop torque mode: FOC rotates the field vector with the rotor so
-        # torque stays constant regardless of angular position.  Fixed-angle voltage
-        # (uq_ud_ext_mode) gives torque ∝ cos(N·θ) and saturates at a fixed angle
-        # set by pole geometry, making displacement independent of pulse duration.
+        # torque stays constant regardless of angular position.
         self.fields.UQ_UD_EXT.write(0, 0)
         self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
         self.fields.PHI_E_SELECTION.write(3)
         self.fields.MODE_MOTION.write(MotionMode.torque_mode)
 
+        pulse_displacements = []
         try:
-            pulse_displacements = []
+            # Phase 1: successive approximation — find the smallest current that
+            # produces ~target_counts displacement so the motor settles within
+            # settle_duration.  Start at 20 mA and scale up proportionally.
+            iq_lsbs = max(round(20.0 / current_scale), 1)
+            d_cal = 0
+            for _iter in range(10):
+                iq_lsbs = min(iq_lsbs, max_iq_lsbs)
+                self.fields.ABN_DECODER_COUNT.write(0)
+                self.fields.PID_TORQUE_FLUX_TARGET.write(0, iq_lsbs)
+                dwell(dt)
+                self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
+                dwell(settle)
+                raw = self.fields.ABN_DECODER_COUNT.read()
+                if raw > 0x7FFFFFFF:
+                    raw -= 0x100000000
+                d_cal = abs(raw)
+                if d_cal >= target_counts:
+                    break
+                if iq_lsbs >= max_iq_lsbs:
+                    break
+                if d_cal >= 4:
+                    # Proportional step with slight undershoot to avoid overshoot
+                    iq_lsbs = min(
+                        round(iq_lsbs * target_counts / d_cal * 0.9),
+                        max_iq_lsbs)
+                else:
+                    iq_lsbs = min(iq_lsbs * 2, max_iq_lsbs)
+
+            if d_cal < 2:
+                logging.warning(
+                    "TMC 4671 '%s' inertia: displacement too small (%d counts) "
+                    "at max current — motor may be constrained or PPR "
+                    "misconfigured, skipping",
+                    self.stepper_name, d_cal)
+                return
+
+            iq_a = iq_lsbs * current_scale * 1e-3
+
+            # Phase 2: 4-pulse measurement with the found current.
             for sign in (+1, -1):
                 for _ in range(2):
                     self.fields.ABN_DECODER_COUNT.write(0)
@@ -1661,13 +1702,15 @@ class TMC4671:
                     self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
                     dwell(settle)
                     raw = self.fields.ABN_DECODER_COUNT.read()
-                    # Interpret as signed 32-bit
                     if raw > 0x7FFFFFFF:
                         raw -= 0x100000000
                     pulse_displacements.append(abs(raw))
         finally:
             self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
             self.fields.MODE_MOTION.write(MotionMode.stopped_mode)
+
+        if len(pulse_displacements) < 4:
+            return
 
         d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2 = pulse_displacements
 
@@ -1693,8 +1736,8 @@ class TMC4671:
         backlash = ((d_fwd_2 - d_fwd_1) + (d_bwd_2 - d_bwd_1)) / 2.0
         logging.info(
             "TMC 4671 '%s' inertia: Kt/J=%.2f rad/s²/A, backlash≈%.1f counts "
-            "(PPR=%d, fwd=[%d,%d], bwd=[%d,%d])",
-            self.stepper_name, self.motor_jt, backlash, ppr,
+            "(PPR=%d, cal=%d, fwd=[%d,%d], bwd=[%d,%d])",
+            self.stepper_name, self.motor_jt, backlash, ppr, d_cal,
             d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2)
 
     cmd_TMC_MEASURE_INERTIA_help = (
@@ -1710,7 +1753,7 @@ class TMC4671:
                                         minval=0.01, maxval=2.0)
         settle_duration = gcmd.get_float('SETTLE_DURATION', 1.0,
                                          minval=0.1, maxval=5.0)
-        current_override = gcmd.get_float('CURRENT', None, minval=0.1)
+        max_current = gcmd.get_float('MAX_CURRENT', None, minval=0.1)
         toolhead = self.printer.lookup_object('toolhead')
         enable_line = self.stepper_enable.lookup_enable(self.stepper_name)
         dwell = toolhead.dwell
@@ -1742,13 +1785,14 @@ class TMC4671:
                 try:
                     vm = self._read_vm()
                     run_current = self.current_helper.get_run_current()
-                    target_a = (min(current_override, run_current)
-                                if current_override is not None
+                    max_iq_a = (min(max_current, run_current)
+                                if max_current is not None
                                 else run_current / 2.0)
-                    iq_lsbs = round(
-                        target_a * 1e3 / self.current_helper.current_scale)
+                    max_iq_lsbs = round(
+                        max_iq_a * 1e3 / self.current_helper.current_scale)
+                    align_a = run_current / 2.0
                     align_u = min(
-                        round((target_a * self.motor_r / vm) * 32767.0),
+                        round((align_a * self.motor_r / vm) * 32767.0),
                         16383)
                     align_u = max(align_u, 200)
 
@@ -1762,9 +1806,10 @@ class TMC4671:
                     dwell(0.75)
                     self.fields.ABN_DECODER_COUNT.write(0)
 
-                    self._measure_inertia_ratio(dwell, iq_lsbs,
+                    self._measure_inertia_ratio(dwell,
                                                 dt=pulse_duration,
-                                                settle=settle_duration)
+                                                settle=settle_duration,
+                                                max_iq_lsbs=max_iq_lsbs)
                 finally:
                     self.fields.UQ_UD_EXT.write(0, 0)
                     self.fields.MODE_MOTION.write(MotionMode.stopped_mode)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1611,14 +1611,7 @@ class TMC4671:
             self.fields.HALL_PHI_E_OFFSET.write(-self.fields.HALL_PHI_E.read() % 65536)
             self.fields.ABN_DECODER_COUNT.write(0)
             self.fields.ABN_DECODER_PHI_E_OFFSET.write(0)
-            try:
-                iq_lsbs = round(
-                    self.current_helper.get_run_current() * 500.0
-                    / self.current_helper.current_scale)
-                self._measure_inertia_ratio(dwell, iq_lsbs)
-            except Exception as e:
-                logging.warning("TMC 4671 '%s' inertia measurement failed: %s",
-                                self.stepper_name, str(e))
+
         # Put motion config back how it was / safe stopped state
         self.fields.UQ_UD_EXT.write(0, 0)
         self._reset_targets()
@@ -1629,8 +1622,8 @@ class TMC4671:
         self._setup_filters()
 
     # Measure Kt/J ratio via 4-pulse accel+brake cycles in closed-loop torque mode
-    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.05):
-        settle = max(0.3, dt)  # settling time between pulse pairs [s]
+    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.05, settle=1.0):
+        settle = max(settle, dt)  # settling time between pulse pairs [s]
 
         ppr = self.fields.ABN_DECODER_PPR.read()
         if ppr == 0:
@@ -1719,6 +1712,8 @@ class TMC4671:
                 "Run startup calibration (FIRMWARE_RESTART) first.")
         pulse_duration = gcmd.get_float('PULSE_DURATION', 0.05,
                                         minval=0.01, maxval=2.0)
+        settle_duration = gcmd.get_float('SETTLE_DURATION', 1.0,
+                                         minval=0.1, maxval=5.0)
         current_override = gcmd.get_float('CURRENT', None, minval=0.1)
         toolhead = self.printer.lookup_object('toolhead')
         enable_line = self.stepper_enable.lookup_enable(self.stepper_name)
@@ -1772,7 +1767,8 @@ class TMC4671:
                     self.fields.ABN_DECODER_COUNT.write(0)
 
                     self._measure_inertia_ratio(dwell, iq_lsbs,
-                                                dt=pulse_duration)
+                                                dt=pulse_duration,
+                                                settle=settle_duration)
                 finally:
                     self.fields.UQ_UD_EXT.write(0, 0)
                     self.fields.MODE_MOTION.write(MotionMode.stopped_mode)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1656,11 +1656,15 @@ class TMC4671:
                 self.fields.ABN_DECODER_COUNT.write(0)
                 self.fields.UQ_EXT.write(sign * iq_test_u)
                 dwell(dt)
+                # Read at the peak of the accel phase, before braking starts.
+                # d_mid = ½·α·dt²; this avoids contamination from friction
+                # asymmetry during the braking phase (which can cause the motor
+                # to bounce back and land at an unpredictable resting position).
+                raw = self.fields.ABN_DECODER_COUNT.read()
                 self.fields.UQ_EXT.write(-sign * iq_test_u)
                 dwell(dt)
                 self.fields.UQ_EXT.write(0)
                 dwell(settle)
-                raw = self.fields.ABN_DECODER_COUNT.read()
                 # Interpret as signed 32-bit
                 if raw > 0x7FFFFFFF:
                     raw -= 0x100000000
@@ -1681,8 +1685,8 @@ class TMC4671:
 
         d_avg = (d_fwd + d_bwd) / 2.0
 
-        # d = alpha * dt^2  →  alpha [rad/s²] = d [counts] * 2π / (PPR * dt²)
-        alpha = d_avg * 2.0 * math.pi / (ppr * dt * dt)
+        # d_mid = ½·alpha·dt²  →  alpha [rad/s²] = d_mid [counts] * 4π / (PPR * dt²)
+        alpha = d_avg * 4.0 * math.pi / (ppr * dt * dt)
         self.motor_jt = alpha / iq_a   # Kt/J  [rad s⁻² A⁻¹]
 
         backlash = ((d_fwd_2 - d_fwd_1) + (d_bwd_2 - d_bwd_1)) / 2.0

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1713,6 +1713,11 @@ class TMC4671:
                     other.error_helper.stop_checks()
                     other.fields.MODE_MOTION.write(MotionMode.stopped_mode)
                     other.fields.PWM_CHOP.write(0)
+                    if other.fields6100 is not None:
+                        other.mcu_tmc6100.set_register(
+                            "GCONF",
+                            other.fields6100.set_field("disable", 1),
+                            None)
 
             with self.mutex:
                 print_time = toolhead.get_last_move_time()
@@ -1754,6 +1759,11 @@ class TMC4671:
             for other in others:
                 with other.mutex:
                     other.fields.PWM_CHOP.write(7)
+                    if other.fields6100 is not None:
+                        other.mcu_tmc6100.set_register(
+                            "GCONF",
+                            other.fields6100.set_field("disable", 0),
+                            None)
 
         if self.motor_jt == 0.0:
             gcmd.respond_info(

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1658,15 +1658,9 @@ class TMC4671:
                     self.fields.ABN_DECODER_COUNT.write(0)
                     self.fields.PID_TORQUE_FLUX_TARGET.write(0, sign * iq_lsbs)
                     dwell(dt)
-                    # Read at the peak of the accel phase, before braking starts.
-                    # d_mid = ½·α·dt²; this avoids contamination from friction
-                    # asymmetry during the braking phase (which can cause the motor
-                    # to bounce back and land at an unpredictable resting position).
-                    raw = self.fields.ABN_DECODER_COUNT.read()
-                    self.fields.PID_TORQUE_FLUX_TARGET.write(0, -sign * iq_lsbs)
-                    dwell(dt)
                     self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
                     dwell(settle)
+                    raw = self.fields.ABN_DECODER_COUNT.read()
                     # Interpret as signed 32-bit
                     if raw > 0x7FFFFFFF:
                         raw -= 0x100000000
@@ -1690,7 +1684,9 @@ class TMC4671:
 
         d_avg = (d_fwd + d_bwd) / 2.0
 
-        # d_mid = ½·alpha·dt²  →  alpha [rad/s²] = d_mid [counts] * 4π / (PPR * dt²)
+        # d = total displacement (accel + unbraked coast-to-stop).
+        # Approximation: d ≈ ½·alpha·dt²  →  alpha [rad/s²] = d * 4π / (PPR * dt²)
+        # Coast contribution means motor_jt is a slight upper bound on true Kt/J.
         alpha = d_avg * 4.0 * math.pi / (ppr * dt * dt)
         self.motor_jt = alpha / iq_a   # Kt/J  [rad s⁻² A⁻¹]
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1612,7 +1612,10 @@ class TMC4671:
             self.fields.ABN_DECODER_COUNT.write(0)
             self.fields.ABN_DECODER_PHI_E_OFFSET.write(0)
             try:
-                self._measure_inertia_ratio(dwell, test2_U, vm)
+                iq_lsbs = round(
+                    self.current_helper.get_run_current() * 500.0
+                    / self.current_helper.current_scale)
+                self._measure_inertia_ratio(dwell, iq_lsbs)
             except Exception as e:
                 logging.warning("TMC 4671 '%s' inertia measurement failed: %s",
                                 self.stepper_name, str(e))
@@ -1625,8 +1628,8 @@ class TMC4671:
         # Re-enable the configured biquad filters
         self._setup_filters()
 
-    # Measure Kt/J ratio via 4-pulse accel+brake cycles in UQ/UD-EXT mode
-    def _measure_inertia_ratio(self, dwell, iq_test_u, vm, dt=0.2):
+    # Measure Kt/J ratio via 4-pulse accel+brake cycles in closed-loop torque mode
+    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.2):
         settle = max(0.3, dt)  # settling time between pulse pairs [s]
 
         ppr = self.fields.ABN_DECODER_PPR.read()
@@ -1635,40 +1638,49 @@ class TMC4671:
                             self.stepper_name)
             return
 
-        if iq_test_u == 0 or self.motor_r < 1e-6:
-            logging.warning("TMC 4671 '%s' inertia: test voltage or R is zero, skipping",
+        if iq_lsbs == 0:
+            logging.warning("TMC 4671 '%s' inertia: test current is zero, skipping",
                             self.stepper_name)
             return
 
-        # DC-approximation current [A]: I ≈ V_q / R  (back-EMF negligible at these speeds)
-        iq_a = (iq_test_u / 32767.0) * vm / self.motor_r
+        iq_a = iq_lsbs * self.current_helper.current_scale * 1e-3
         if iq_a < 1e-6:
             logging.warning("TMC 4671 '%s' inertia: computed IQ too small (%.4f A), skipping",
                             self.stepper_name, iq_a)
             return
 
-        # Release d-axis hold so the rotor can rotate freely under q-axis torque
-        self.fields.UD_EXT.write(0)
+        # Closed-loop torque mode: FOC rotates the field vector with the rotor so
+        # torque stays constant regardless of angular position.  Fixed-angle voltage
+        # (uq_ud_ext_mode) gives torque ∝ cos(N·θ) and saturates at a fixed angle
+        # set by pole geometry, making displacement independent of pulse duration.
+        self.fields.UQ_UD_EXT.write(0, 0)
+        self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
+        self.fields.PHI_E_SELECTION.write(3)
+        self.fields.MODE_MOTION.write(MotionMode.torque_mode)
 
-        pulse_displacements = []
-        for sign in (+1, -1):
-            for _ in range(2):
-                self.fields.ABN_DECODER_COUNT.write(0)
-                self.fields.UQ_EXT.write(sign * iq_test_u)
-                dwell(dt)
-                # Read at the peak of the accel phase, before braking starts.
-                # d_mid = ½·α·dt²; this avoids contamination from friction
-                # asymmetry during the braking phase (which can cause the motor
-                # to bounce back and land at an unpredictable resting position).
-                raw = self.fields.ABN_DECODER_COUNT.read()
-                self.fields.UQ_EXT.write(-sign * iq_test_u)
-                dwell(dt)
-                self.fields.UQ_EXT.write(0)
-                dwell(settle)
-                # Interpret as signed 32-bit
-                if raw > 0x7FFFFFFF:
-                    raw -= 0x100000000
-                pulse_displacements.append(abs(raw))
+        try:
+            pulse_displacements = []
+            for sign in (+1, -1):
+                for _ in range(2):
+                    self.fields.ABN_DECODER_COUNT.write(0)
+                    self.fields.PID_TORQUE_FLUX_TARGET.write(0, sign * iq_lsbs)
+                    dwell(dt)
+                    # Read at the peak of the accel phase, before braking starts.
+                    # d_mid = ½·α·dt²; this avoids contamination from friction
+                    # asymmetry during the braking phase (which can cause the motor
+                    # to bounce back and land at an unpredictable resting position).
+                    raw = self.fields.ABN_DECODER_COUNT.read()
+                    self.fields.PID_TORQUE_FLUX_TARGET.write(0, -sign * iq_lsbs)
+                    dwell(dt)
+                    self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
+                    dwell(settle)
+                    # Interpret as signed 32-bit
+                    if raw > 0x7FFFFFFF:
+                        raw -= 0x100000000
+                    pulse_displacements.append(abs(raw))
+        finally:
+            self.fields.PID_TORQUE_FLUX_TARGET.write(0, 0)
+            self.fields.MODE_MOTION.write(MotionMode.stopped_mode)
 
         d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2 = pulse_displacements
 
@@ -1738,9 +1750,12 @@ class TMC4671:
 
                 try:
                     vm = self._read_vm()
-                    target_a = (current_override
+                    run_current = self.current_helper.get_run_current()
+                    target_a = (min(current_override, run_current)
                                 if current_override is not None
-                                else self.current_helper.get_run_current() / 2.0)
+                                else run_current / 2.0)
+                    iq_lsbs = round(
+                        target_a * 1e3 / self.current_helper.current_scale)
                     align_u = min(
                         round((target_a * self.motor_r / vm) * 32767.0),
                         16383)
@@ -1756,7 +1771,7 @@ class TMC4671:
                     dwell(0.75)
                     self.fields.ABN_DECODER_COUNT.write(0)
 
-                    self._measure_inertia_ratio(dwell, align_u, vm,
+                    self._measure_inertia_ratio(dwell, iq_lsbs,
                                                 dt=pulse_duration)
                 finally:
                     self.fields.UQ_UD_EXT.write(0, 0)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1629,7 +1629,7 @@ class TMC4671:
         self._setup_filters()
 
     # Measure Kt/J ratio via 4-pulse accel+brake cycles in closed-loop torque mode
-    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.2):
+    def _measure_inertia_ratio(self, dwell, iq_lsbs, dt=0.05):
         settle = max(0.3, dt)  # settling time between pulse pairs [s]
 
         ppr = self.fields.ABN_DECODER_PPR.read()
@@ -1717,8 +1717,8 @@ class TMC4671:
             raise gcmd.error(
                 "Motor resistance not calibrated. "
                 "Run startup calibration (FIRMWARE_RESTART) first.")
-        pulse_duration = gcmd.get_float('PULSE_DURATION', 0.2,
-                                        minval=0.05, maxval=2.0)
+        pulse_duration = gcmd.get_float('PULSE_DURATION', 0.05,
+                                        minval=0.01, maxval=2.0)
         current_override = gcmd.get_float('CURRENT', None, minval=0.1)
         toolhead = self.printer.lookup_object('toolhead')
         enable_line = self.stepper_enable.lookup_enable(self.stepper_name)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -923,6 +923,7 @@ class TMC4671:
         self.motor_ld = 0.0
         self.motor_lq = 0.0
         self.motor_saliency = 1.0
+        self.motor_jt = 0.0
         self.dead_time_v = 0.0
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, field_meta,
                                    TMC_FREQUENCY, pin_option="cs_pin")
@@ -1596,6 +1597,11 @@ class TMC4671:
             self.fields.HALL_PHI_E_OFFSET.write(-self.fields.HALL_PHI_E.read() % 65536)
             self.fields.ABN_DECODER_COUNT.write(0)
             self.fields.ABN_DECODER_PHI_E_OFFSET.write(0)
+            try:
+                self._measure_inertia_ratio(dwell, test2_U, vm)
+            except Exception as e:
+                logging.warning("TMC 4671 '%s' inertia measurement failed: %s",
+                                self.stepper_name, str(e))
         # Put motion config back how it was / safe stopped state
         self.fields.UQ_UD_EXT.write(0, 0)
         self._reset_targets()
@@ -1604,6 +1610,74 @@ class TMC4671:
 
         # Re-enable the configured biquad filters
         self._setup_filters()
+
+    # Measure Kt/J ratio via 4-pulse accel+brake cycles in UQ/UD-EXT mode
+    def _measure_inertia_ratio(self, dwell, iq_test_u, vm):
+        dt = 0.2      # accel / brake phase duration [s]
+        settle = 0.3  # settling time between pulse pairs [s]
+
+        ppr = self.fields.ABN_DECODER_PPR.read()
+        if ppr == 0:
+            logging.warning("TMC 4671 '%s' inertia: ABN_DECODER_PPR=0, skipping",
+                            self.stepper_name)
+            return
+
+        if iq_test_u == 0 or self.motor_r < 1e-6:
+            logging.warning("TMC 4671 '%s' inertia: test voltage or R is zero, skipping",
+                            self.stepper_name)
+            return
+
+        # DC-approximation current [A]: I ≈ V_q / R  (back-EMF negligible at these speeds)
+        iq_a = (iq_test_u / 32767.0) * vm / self.motor_r
+        if iq_a < 1e-6:
+            logging.warning("TMC 4671 '%s' inertia: computed IQ too small (%.4f A), skipping",
+                            self.stepper_name, iq_a)
+            return
+
+        # Release d-axis hold so the rotor can rotate freely under q-axis torque
+        self.fields.UD_EXT.write(0)
+
+        pulse_displacements = []
+        for sign in (+1, -1):
+            for _ in range(2):
+                self.fields.ABN_DECODER_COUNT.write(0)
+                self.fields.UQ_EXT.write(sign * iq_test_u)
+                dwell(dt)
+                self.fields.UQ_EXT.write(-sign * iq_test_u)
+                dwell(dt)
+                self.fields.UQ_EXT.write(0)
+                dwell(settle)
+                raw = self.fields.ABN_DECODER_COUNT.read()
+                # Interpret as signed 32-bit
+                if raw > 0x7FFFFFFF:
+                    raw -= 0x100000000
+                pulse_displacements.append(abs(raw))
+
+        d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2 = pulse_displacements
+
+        # Use the second pulse per direction (first may absorb backlash)
+        d_fwd = d_fwd_2
+        d_bwd = d_bwd_2
+
+        if d_fwd < 2 and d_bwd < 2:
+            logging.warning(
+                "TMC 4671 '%s' inertia: displacement too small (%d, %d counts) — "
+                "motor may be constrained or PPR misconfigured, skipping",
+                self.stepper_name, d_fwd, d_bwd)
+            return
+
+        d_avg = (d_fwd + d_bwd) / 2.0
+
+        # d = alpha * dt^2  →  alpha [rad/s²] = d [counts] * 2π / (PPR * dt²)
+        alpha = d_avg * 2.0 * math.pi / (ppr * dt * dt)
+        self.motor_jt = alpha / iq_a   # Kt/J  [rad s⁻² A⁻¹]
+
+        backlash = ((d_fwd_2 - d_fwd_1) + (d_bwd_2 - d_bwd_1)) / 2.0
+        logging.info(
+            "TMC 4671 '%s' inertia: Kt/J=%.2f rad/s²/A, backlash≈%.1f counts "
+            "(PPR=%d, fwd=[%d,%d], bwd=[%d,%d])",
+            self.stepper_name, self.motor_jt, backlash, ppr,
+            d_fwd_1, d_fwd_2, d_bwd_1, d_bwd_2)
 
     # Tune PID via a setpoint change experiment
     # See https://folk.ntnu.no/skoge/publications/2012/skogestad-improved-simc-pid/PIDbook-chapter5.pdf
@@ -2243,6 +2317,7 @@ class TMC4671:
         ld_str = f"{self.motor_ld:.6f} H ({self.motor_ld * 1000.0:.3f} mH)" if self.motor_ld != 0.0 else "Not yet calibrated / measured"
         lq_str = f"{self.motor_lq:.6f} H ({self.motor_lq * 1000.0:.3f} mH)" if self.motor_lq != 0.0 else "Not yet calibrated / measured"
         sal_str = f"{self.motor_saliency:.4f}" if self.motor_saliency != 1.0 else "Not yet calibrated / measured"
+        jt_str = f"{self.motor_jt:.2f} rad/s\u00b2/A" if self.motor_jt != 0.0 else "Not yet measured"
 
         def _biquad_str(target):
             bf = self.biquad_filters[target]
@@ -2257,6 +2332,7 @@ class TMC4671:
             f"  Estimated Ld Inductance (motor_ld): {ld_str}\n"
             f"  Estimated Lq Inductance (motor_lq): {lq_str}\n"
             f"  Saliency Ratio (motor_saliency): {sal_str}\n"
+            f"  Inertia ratio (Kt/J): {jt_str}\n"
             f"  Current Loop Filters:\n"
             f"    Flux:   {_biquad_str('flux')}\n"
             f"    Torque: {_biquad_str('torque')}"


### PR DESCRIPTION
Adds `_measure_inertia_ratio` which runs automatically after `_align_and_measure` during startup calibration.

## Method

Uses 4 accel+brake pulse pairs in UQ/UD-EXT mode with the rotor already aligned at PHI_E=0:

- For each direction (forward/backward), apply `+Iq` for 200 ms then `-Iq` for 200 ms, settle 300 ms, read `ABN_DECODER_COUNT`
- Equal accel+brake phases give net displacement `d = α·dt²`
- Use the **second** pulse per direction (first absorbs backlash slack)
- `α [rad/s²] = d·2π / (PPR·dt²)`
- `Kt/J = α / Iq_A` where `Iq_A ≈ Vq/R` (DC approximation, valid at these slow speeds ~1.7 rpm)

Backlash is estimated from the difference between first and second pulse displacements.

Total added startup time: ~2.8 s (4 × 0.7 s).

## Storage

`self.motor_jt` [rad·s⁻²·A⁻¹] — initialised to `0.0` in `__init__`. Reported by `TMC_DEBUG_MOTOR`.

## Failure handling

Wrapped in `try/except` — any failure logs a warning and leaves `motor_jt = 0.0` without aborting calibration.

## Future use

`motor_jt` will be used in `_tune_motion_pid` to auto-derive the velocity loop gain from measured motor dynamics.