### PR TITLE
Add physics-based velocity/position PID tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ TMC_TUNE_MOTION_PID STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [L
 
 Motor physics config variables (set in `[tmc4671 stepper_x]`): `jmotor` (default 8.45e-6 kg·m²), `jload` (default 5e-5 kg·m²), `motor_kt` (default 0.0156 Nm/A), `velocity_alpha` (default 0.35).
 
+The velocity biquad LPF is automatically set to the velocity bandwidth (bandwidth path) or `3 × pwmfreq / LAMBDA_V` (SIMC path) and queued for `SAVE_CONFIG` alongside the PID gains.
+
 ### TMC_DEBUG_TUNING
 
 Report what the PID tuning helpers would compute given the current motor parameters, without writing anything to the controller. Compares computed values against the currently active register values. Always shows the bandwidth-method section; shows the SIMC/lambda motion PID section only when `KT` is supplied.

--- a/README.md
+++ b/README.md
@@ -283,43 +283,53 @@ PID stepper_x parameters:
 
 ### TMC_TUNE_MOTION_PID
 
-Autotune velocity and position PID coefficients using S-IMC and queue the results for `SAVE_CONFIG`.
+Autotune velocity and position PID coefficients and queue the results for `SAVE_CONFIG`.
+
+Two paths are available:
+
+- **Bandwidth path** (default): computes gains from motor physics config variables (`jmotor`, `jload`, `motor_kt`, `velocity_alpha`). No extra parameters needed.
+- **SIMC/lambda path**: uses measured Kt and lambda time constants. Activated by supplying `KT` (or `HOLDING_CURRENT`+`HOLDING_TORQUE`).
 
 ```
+TMC_TUNE_MOTION_PID STEPPER=stepper_x [VELOCITY_BANDWIDTH=<hz>] [POSITION_BANDWIDTH=<hz>]
 TMC_TUNE_MOTION_PID STEPPER=stepper_x KT=<nm/a> [LAMBDA_V=<val>] [LAMBDA_P=<val>]
 TMC_TUNE_MOTION_PID STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [LAMBDA_V=<val>] [LAMBDA_P=<val>]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
-| `KT` | — | Motor torque constant in Nm/A. |
+| `VELOCITY_BANDWIDTH` | 450.0 | Velocity loop bandwidth in Hz (bandwidth path). |
+| `POSITION_BANDWIDTH` | 100.0 | Position loop bandwidth in Hz (bandwidth path). |
+| `KT` | — | Motor torque constant in Nm/A. Selects SIMC/lambda path. |
 | `HOLDING_CURRENT` | — | Rated holding current in A (alternative to `KT`). |
 | `HOLDING_TORQUE` | — | Rated holding torque in Nm (alternative to `KT`). |
-| `LAMBDA_V` | 100.0 | Velocity loop closed-loop time constant (smaller = faster/noisier). |
-| `LAMBDA_P` | 400.0 | Position loop closed-loop time constant. Should be at least 2× `LAMBDA_V`. |
+| `LAMBDA_V` | 100.0 | Velocity loop closed-loop time constant (SIMC path; smaller = faster/noisier). |
+| `LAMBDA_P` | 400.0 | Position loop closed-loop time constant (SIMC path; should be ≥ 2× `LAMBDA_V`). |
 
-The command also suggests biquad filter frequencies but does not apply them.
+Motor physics config variables (set in `[tmc4671 stepper_x]`): `jmotor` (default 8.45e-6 kg·m²), `jload` (default 5e-5 kg·m²), `motor_kt` (default 0.0156 Nm/A), `velocity_alpha` (default 0.35).
 
 ### TMC_DEBUG_TUNING
 
-Report what the PID tuning helpers would compute given the current motor parameters, without writing anything to the controller. Compares computed values against the currently active register values.
+Report what the PID tuning helpers would compute given the current motor parameters, without writing anything to the controller. Compares computed values against the currently active register values. Always shows the bandwidth-method section; shows the SIMC/lambda motion PID section only when `KT` is supplied.
 
 ```
-TMC_DEBUG_TUNING STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [LAMBDA_V=<val>] [LAMBDA_P=<val>] [KT=<nm/a>] [R=<ohm>] [L=<henry>]
+TMC_DEBUG_TUNING STEPPER=stepper_x [CURRENT_BANDWIDTH=<hz>] [VELOCITY_BANDWIDTH=<hz>] [POSITION_BANDWIDTH=<hz>] [LAMBDA_V=<val>] [LAMBDA_P=<val>] [KT=<nm/a>] [R=<ohm>] [L=<henry>]
 TMC_DEBUG_TUNING STEPPER=stepper_x HOLDING_CURRENT=<a> HOLDING_TORQUE=<nm> [...]
 ```
 
 | Parameter | Default | Description |
 |---|---|---|
-| `CURRENT_BANDWIDTH` | 1200.0 | Bandwidth in Hz for the current PID calculation. |
-| `LAMBDA_V` | 100.0 | Velocity loop time constant for the motion PID calculation. |
-| `LAMBDA_P` | 400.0 | Position loop time constant for the motion PID calculation. |
-| `KT` | — | Motor torque constant in Nm/A (required for motion PID section). |
+| `CURRENT_BANDWIDTH` | 1200.0 | Bandwidth in Hz for the current PID section. |
+| `VELOCITY_BANDWIDTH` | 450.0 | Velocity loop bandwidth in Hz for the bandwidth motion PID section. |
+| `POSITION_BANDWIDTH` | 100.0 | Position loop bandwidth in Hz for the bandwidth motion PID section. |
+| `LAMBDA_V` | 100.0 | Velocity loop time constant for the SIMC motion PID section. |
+| `LAMBDA_P` | 400.0 | Position loop time constant for the SIMC motion PID section. |
+| `KT` | — | Motor torque constant in Nm/A (required to show SIMC motion PID section). |
 | `HOLDING_CURRENT` + `HOLDING_TORQUE` | — | Alternative way to supply Kt. |
 | `R` | — | Override motor winding resistance in Ω. Defaults to the measured value. |
 | `L` | — | Override motor winding inductance in H. Defaults to the measured value. |
 
-If motor R and L have not yet been measured (startup alignment pending), the current PID section reports that instead of computing. Providing `R` or `L` overrides the measured value for the computation without changing what is stored; the output labels overridden values accordingly. The motion PID section is skipped if no torque constant is provided.
+If motor R and L have not yet been measured (startup alignment pending), the current PID section reports that instead of computing. Providing `R` or `L` overrides the measured value for the computation without changing what is stored; the output labels overridden values accordingly.
 
 ### SET_TMC_BIQUAD_FILTER
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1807,29 +1807,36 @@ class TMC4671:
             l_v = l_v if l_v is not None else 100.0
             l_p = l_p if l_p is not None else 400.0
             p_v, i_v, p_p, i_p, k_v, k_p = self._tune_motion_pid(Kt, l_v, l_p)
+            vel_filter_freq = round(3.0 * self.pwmfreq / l_v)
             msg = (
                 "Motion PID %s (SIMC/lambda).\n"
                 "k_v=%.5f  k_p=%.5f  KT=%.5f\n"
                 "Velocity P=%.5f  I=%.5f\n"
                 "Position  P=%.5f  I=%.5f\n"
-                "Suggested velocity/torque filter frequency: %d Hz\n"
+                "Velocity biquad LPF set to %d Hz\n"
                 "SAVE_CONFIG will write these values and restart."
-                % (self.name, k_v, k_p, Kt, p_v, i_v, p_p, i_p,
-                   round(3.0 * self.pwmfreq / l_v))
+                % (self.name, k_v, k_p, Kt, p_v, i_v, p_p, i_p, vel_filter_freq)
             )
         else:
             p_v, i_v = self._calc_velocity_pid(v_bw)
             p_p = self._calc_position_pid(v_bw, p_bw)
             i_p = 0.0
+            vel_filter_freq = round(v_bw)
             msg = (
                 "Motion PID %s (bandwidth).\n"
                 "Velocity bandwidth=%.1f Hz  Position bandwidth=%.1f Hz\n"
                 "Velocity P=%.5f  I=%.5f\n"
                 "Position  P=%.5f  I=%.5f\n"
+                "Velocity biquad LPF set to %d Hz\n"
                 "SAVE_CONFIG will write these values and restart."
-                % (self.name, v_bw, p_bw, p_v, i_v, p_p, i_p)
+                % (self.name, v_bw, p_bw, p_v, i_v, p_p, i_p, vel_filter_freq)
             )
 
+        vel_filter = BiquadFilter(
+            type='lpf', freq=vel_filter_freq,
+            slope=self.biquad_filters['velocity'].slope)
+        self.biquad_filters['velocity'] = vel_filter
+        self._setup_filter(BIQUAD_FILTER_TARGETS['velocity'], vel_filter)
         self.fields.PID_VELOCITY_P.write(self.pid_helpers["VELOCITY_P"].to_f(p_v))
         self.fields.PID_VELOCITY_I.write(self.pid_helpers["VELOCITY_I"].to_f(i_v))
         self.fields.PID_POSITION_P.write(self.pid_helpers["POSITION_P"].to_f(p_p))
@@ -1840,6 +1847,10 @@ class TMC4671:
         configfile.set(cfgname, 'foc_PID_VELOCITY_I', "%.3f" % (i_v,))
         configfile.set(cfgname, 'foc_PID_POSITION_P', "%.3f" % (p_p,))
         configfile.set(cfgname, 'foc_PID_POSITION_I', "%.3f" % (i_p,))
+        bf = self.biquad_filters['velocity']
+        configfile.set(cfgname, 'biquad_velocity_filter', bf.type)
+        configfile.set(cfgname, 'biquad_velocity_frequency', "%d" % (bf.freq,))
+        configfile.set(cfgname, 'biquad_velocity_slope', "%.6g" % (bf.slope,))
         gcmd.respond_info(msg)
 
     cmd_TMC_TUNE_PID_help = "Tune the current and torque PID coefficients"

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1398,9 +1398,9 @@ class TMC4671:
         velocity_i = (1.0 - self.velocity_alpha) * omega_bw / (4.0 * f_loop)
         return velocity_p, velocity_i
 
-    def _calc_position_pid(self, velocity_bandwidth, position_bandwidth):
+    def _calc_position_pid(self, position_bandwidth):
         npoles = self.fields.N_POLE_PAIRS.read()
-        position_p = velocity_bandwidth * 60.0 * npoles / (position_bandwidth * 65536.0)
+        position_p = 2.0 * math.pi * position_bandwidth / npoles
         return position_p
 
     # Align motor and measure resistance and inductance on startup
@@ -1819,7 +1819,7 @@ class TMC4671:
             )
         else:
             p_v, i_v = self._calc_velocity_pid(v_bw)
-            p_p = self._calc_position_pid(v_bw, p_bw)
+            p_p = self._calc_position_pid(p_bw)
             i_p = 0.0
             vel_filter_freq = round(v_bw)
             msg = (
@@ -2437,7 +2437,7 @@ class TMC4671:
             "  POSITION_BANDWIDTH=%.1f Hz) ---" % (v_bw, p_bw)
         )
         p_v_bw, i_v_bw = self._calc_velocity_pid(v_bw)
-        p_p_bw = self._calc_position_pid(v_bw, p_bw)
+        p_p_bw = self._calc_position_pid(p_bw)
         p_v_cur = self.pid_helpers["VELOCITY_P"].from_f(
             self.fields.PID_VELOCITY_P.read()
         )

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -924,6 +924,11 @@ class TMC4671:
         self.motor_lq = 0.0
         self.motor_saliency = 1.0
         self.dead_time_v = 0.0
+        self.jmotor = config.getfloat('jmotor', 8.45e-6, above=0.)
+        self.jload  = config.getfloat('jload',  5e-5,    above=0.)
+        self.motor_kt = config.getfloat('motor_kt', 0.0156, above=0.)
+        self.velocity_alpha = config.getfloat('velocity_alpha', 0.35,
+                                              minval=0., maxval=1.)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, field_meta,
                                    TMC_FREQUENCY, pin_option="cs_pin")
         self.fields = FieldProxy(field_meta, self.mcu_tmc)
@@ -1382,6 +1387,16 @@ class TMC4671:
         i_p = 1. / t_ip
 
         return p_v, i_v, p_p, i_p, k_v, k_p
+
+    def _calc_velocity_pid(self, bandwidth):
+        omega_bw = 2.0 * math.pi * bandwidth
+        npoles = self.fields.N_POLE_PAIRS.read()
+        j_total = self.jmotor + self.jload
+        velocity_p = omega_bw * (2.0 * math.pi * j_total) / (60.0 * npoles * self.motor_kt)
+        nsmpl = self.fields.MODE_PID_SMPL.read()
+        f_loop = self.pwmfreq / (nsmpl + 1)
+        velocity_i = (1.0 - self.velocity_alpha) * omega_bw / (4.0 * f_loop)
+        return velocity_p, velocity_i
 
     # Align motor and measure resistance and inductance on startup
     def _align_and_measure(self, offsets, print_time):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1398,6 +1398,11 @@ class TMC4671:
         velocity_i = (1.0 - self.velocity_alpha) * omega_bw / (4.0 * f_loop)
         return velocity_p, velocity_i
 
+    def _calc_position_pid(self, velocity_bandwidth, position_bandwidth):
+        npoles = self.fields.N_POLE_PAIRS.read()
+        position_p = velocity_bandwidth * 60.0 * npoles / (position_bandwidth * 65536.0)
+        return position_p
+
     # Align motor and measure resistance and inductance on startup
     def _align_and_measure(self, offsets, print_time):
         dwell = self.printer.lookup_object('toolhead').dwell
@@ -1786,42 +1791,56 @@ class TMC4671:
         print_time = self.printer.lookup_object('toolhead').get_last_move_time()
         self._init_registers(print_time)
 
-    cmd_TMC_TUNE_MOTION_PID_help = "Tune the current and torque PID coefficients"
+    cmd_TMC_TUNE_MOTION_PID_help = "Tune velocity and position PID coefficients"
     def cmd_TMC_TUNE_MOTION_PID(self, gcmd):
-        l_v = gcmd.get_float('LAMBDA_V', 100)
-        l_p = gcmd.get_float('LAMBDA_P', 400)
+        v_bw = gcmd.get_float('VELOCITY_BANDWIDTH', 450.0, above=0.)
+        p_bw = gcmd.get_float('POSITION_BANDWIDTH', 100.0, above=0.)
+        l_v = gcmd.get_float('LAMBDA_V', None)
+        l_p = gcmd.get_float('LAMBDA_P', None)
         I_h = gcmd.get_float('HOLDING_CURRENT', None)
         T_h = gcmd.get_float('HOLDING_TORQUE', None)
         Kt = gcmd.get_float('KT', None)
-        if Kt is None:
-            if (I_h is None or T_h is None):
-                gcmd.respond_info("Must supply KT or both HOLDING_TORQUE and HOLDING_CURRENT.")
-                return
+        if Kt is None and I_h is not None and T_h is not None:
             Kt = T_h / I_h
-        rotation_distance, _ = self.stepper.get_rotation_distance()
 
-        p_v, i_v, p_p, i_p, k_v, k_p = self._tune_motion_pid(Kt, l_v, l_p)
+        if Kt is not None:
+            l_v = l_v if l_v is not None else 100.0
+            l_p = l_p if l_p is not None else 400.0
+            p_v, i_v, p_p, i_p, k_v, k_p = self._tune_motion_pid(Kt, l_v, l_p)
+            msg = (
+                "Motion PID %s (SIMC/lambda).\n"
+                "k_v=%.5f  k_p=%.5f  KT=%.5f\n"
+                "Velocity P=%.5f  I=%.5f\n"
+                "Position  P=%.5f  I=%.5f\n"
+                "Suggested velocity/torque filter frequency: %d Hz\n"
+                "SAVE_CONFIG will write these values and restart."
+                % (self.name, k_v, k_p, Kt, p_v, i_v, p_p, i_p,
+                   round(3.0 * self.pwmfreq / l_v))
+            )
+        else:
+            p_v, i_v = self._calc_velocity_pid(v_bw)
+            p_p = self._calc_position_pid(v_bw, p_bw)
+            i_p = 0.0
+            msg = (
+                "Motion PID %s (bandwidth).\n"
+                "Velocity bandwidth=%.1f Hz  Position bandwidth=%.1f Hz\n"
+                "Velocity P=%.5f  I=%.5f\n"
+                "Position  P=%.5f  I=%.5f\n"
+                "SAVE_CONFIG will write these values and restart."
+                % (self.name, v_bw, p_bw, p_v, i_v, p_p, i_p)
+            )
 
         self.fields.PID_VELOCITY_P.write(self.pid_helpers["VELOCITY_P"].to_f(p_v))
         self.fields.PID_VELOCITY_I.write(self.pid_helpers["VELOCITY_I"].to_f(i_v))
         self.fields.PID_POSITION_P.write(self.pid_helpers["POSITION_P"].to_f(p_p))
         self.fields.PID_POSITION_I.write(self.pid_helpers["POSITION_I"].to_f(i_p))
-        # Store results for SAVE_CONFIG
         cfgname = "tmc4671 %s" % (self.name,)
         configfile = self.printer.lookup_object('configfile')
         configfile.set(cfgname, 'foc_PID_VELOCITY_P', "%.3f" % (p_v,))
         configfile.set(cfgname, 'foc_PID_VELOCITY_I', "%.3f" % (i_v,))
         configfile.set(cfgname, 'foc_PID_POSITION_P', "%.3f" % (p_p,))
         configfile.set(cfgname, 'foc_PID_POSITION_I', "%.3f" % (i_p,))
-
-        gcmd.respond_info(
-            "PID %s parameters calculated.\n"
-            "k_v=%.5f k_p=%.5f\n KT=%.5f\n"
-            "p_v=%.5f i_v=%.5f p_p=%.5f i_p=%.5f\n"
-            "The SAVE_CONFIG command will update the printer config file\n"
-            "with these parameters and restart the printer.\n"
-            "Suggested torque and velocity filter frequency: %d\n"
-            % (self.name, k_v, k_p, Kt, p_v, i_v, p_p, i_p, 3.0*self.pwmfreq / l_v))
+        gcmd.respond_info(msg)
 
     cmd_TMC_TUNE_PID_help = "Tune the current and torque PID coefficients"
     def cmd_TMC_TUNE_PID(self, gcmd):
@@ -2284,6 +2303,8 @@ class TMC4671:
         current_bandwidth = gcmd.get_float('CURRENT_BANDWIDTH', 1200.0)
         l_v = gcmd.get_float('LAMBDA_V', 100.0)
         l_p = gcmd.get_float('LAMBDA_P', 400.0)
+        v_bw = gcmd.get_float('VELOCITY_BANDWIDTH', 450.0, above=0.)
+        p_bw = gcmd.get_float('POSITION_BANDWIDTH', 100.0, above=0.)
         I_h = gcmd.get_float('HOLDING_CURRENT', None)
         T_h = gcmd.get_float('HOLDING_TORQUE', None)
         Kt = gcmd.get_float('KT', None)
@@ -2398,6 +2419,38 @@ class TMC4671:
                 "  Suggested filter frequency: %d Hz"
                 % round(3.0 * self.pwmfreq / l_v)
             )
+
+        lines.append("")
+        lines.append(
+            "--- Motion PID (bandwidth, VELOCITY_BANDWIDTH=%.1f Hz"
+            "  POSITION_BANDWIDTH=%.1f Hz) ---" % (v_bw, p_bw)
+        )
+        p_v_bw, i_v_bw = self._calc_velocity_pid(v_bw)
+        p_p_bw = self._calc_position_pid(v_bw, p_bw)
+        p_v_cur = self.pid_helpers["VELOCITY_P"].from_f(
+            self.fields.PID_VELOCITY_P.read()
+        )
+        i_v_cur = self.pid_helpers["VELOCITY_I"].from_f(
+            self.fields.PID_VELOCITY_I.read()
+        )
+        p_p_cur = self.pid_helpers["POSITION_P"].from_f(
+            self.fields.PID_POSITION_P.read()
+        )
+        i_p_cur = self.pid_helpers["POSITION_I"].from_f(
+            self.fields.PID_POSITION_I.read()
+        )
+        lines.append(
+            "  Computed:  Velocity P=%.5f  I=%.5f" % (p_v_bw, i_v_bw)
+        )
+        lines.append(
+            "             Position  P=%.5f  I=0.00000" % (p_p_bw,)
+        )
+        lines.append(
+            "  Active:    Velocity P=%.5f  I=%.5f" % (p_v_cur, i_v_cur)
+        )
+        lines.append(
+            "             Position  P=%.5f  I=%.5f" % (p_p_cur, i_p_cur)
+        )
 
         gcmd.respond_info("\n".join(lines))
 


### PR DESCRIPTION
Adds motor physics config variables and a bandwidth-based path for velocity/position PID tuning.

## Changes

- **New config vars** in `[tmc4671 stepper_x]`: `jmotor` (default 8.45e-6 kg·m²), `jload` (default 5e-5 kg·m²), `motor_kt` (default 0.0156 Nm/A), `velocity_alpha` (default 0.35)
- **`_calc_velocity_pid(bandwidth)`**: computes velocity P/I from physics vars using `velocity_p = ω_bw × 2π(Jm+Jl) / (60 × npoles × Kt)` and `velocity_i = (1−α) × ω_bw / (4 × F_loop)`
- **`_calc_position_pid(v_bw, p_bw)`**: computes position P from `v_bw × 60 × npoles / (p_bw × 65536)`
- **`TMC_TUNE_MOTION_PID`**: new bandwidth path (default) using the above helpers; snip SIMC/lambda path still available when `KT` is supplied. Both paths now automatically set and save the velocity biquad LPF.
- **`TMC_DEBUG_TUNING`**: always shows bandwidth-method section; snip SIMC section shown only when `KT` is supplied.
- README updated with both paths, new params, config variables, and velocity biquad note.