### PR TITLE
Hold SPI mutex across biquad enable/disable register writes

### DIFF
--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1299,16 +1299,17 @@ class TMC4671:
     def _sample_adc(self, reg_name):
         self.printer.lookup_object('toolhead').dwell(0.2)
         reg, addr = self.mcu_tmc.name_to_reg[reg_name]
-        self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
         i1 = []
         i0 = []
         n = 100
-        for i in range(n):
-            v = self.fields.get_reg_fields(reg_name,
-                                           self.mcu_tmc.tmc_spi.reg_read(reg))
-            i1.append(v["ADC_I1_RAW"])
-            i0.append(v["ADC_I0_RAW"])
-            self.printer.lookup_object('toolhead').dwell(0.0005)
+        with self.mcu_tmc.tmc_spi.mutex:
+            self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
+            for i in range(n):
+                v = self.fields.get_reg_fields(reg_name,
+                                               self.mcu_tmc.tmc_spi.reg_read(reg))
+                i1.append(v["ADC_I1_RAW"])
+                i0.append(v["ADC_I0_RAW"])
+                self.printer.lookup_object('toolhead').dwell(0.0005)
         return int(round(fmean(i0))), int(round(fmean(i1)))
 
     def _sample_vm(self):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1134,17 +1134,19 @@ class TMC4671:
             )
 
     def enable_biquad(self, enable_field, *biquad):
-        reg, addr = self.mcu_tmc.name_to_reg[enable_field]
-        for o,i in enumerate(biquad):
-            self.mcu_tmc.tmc_spi.reg_write(reg+1, addr-6+o)
-            self.mcu_tmc.tmc_spi.reg_write(reg, i)
-        self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
-        self.mcu_tmc.tmc_spi.reg_write(reg, 1)
+        with self.mcu_tmc.tmc_spi.mutex:
+            reg, addr = self.mcu_tmc.name_to_reg[enable_field]
+            for o, i in enumerate(biquad):
+                self.mcu_tmc.tmc_spi.reg_write(reg+1, addr-6+o)
+                self.mcu_tmc.tmc_spi.reg_write(reg, i)
+            self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
+            self.mcu_tmc.tmc_spi.reg_write(reg, 1)
 
     def disable_biquad(self, enable_field):
-        reg, addr = self.mcu_tmc.name_to_reg[enable_field]
-        self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
-        self.mcu_tmc.tmc_spi.reg_write(reg, 0)
+        with self.mcu_tmc.tmc_spi.mutex:
+            reg, addr = self.mcu_tmc.name_to_reg[enable_field]
+            self.mcu_tmc.tmc_spi.reg_write(reg+1, addr)
+            self.mcu_tmc.tmc_spi.reg_write(reg, 0)
 
     def _do_enable(self, print_time):
         try:


### PR DESCRIPTION
## Problem

`enable_biquad` and `disable_biquad` made multiple raw `reg_write` calls without holding the SPI mutex. Each `reg_write` yields the reactor greenlet at `completion.wait()` while waiting for the SPI response. During any of those yields, the periodic status-check timer (`_do_periodic_check`) could fire, acquire the (now-free) SPI mutex, and issue its own `spi_transfer`.

Klipper's `SerialRetryCommand` registers a per-oid handler for the response in a shared `handlers` dict. The status-check's new command would overwrite `enable_biquad`'s handler, steal its response, complete successfully, and then `del handlers[('spi_transfer_response', oid)]`. When `enable_biquad`'s exhausted-retry cleanup tried to deregister its own handler it got:

```
KeyError: ('spi_transfer_response', 1)
```

This was reproducible by running `SET_TMC_BIQUAD_FILTER` or `TMC_TUNE_PID` multiple times in quick succession.

## Fix

Wrap the full sequence of `reg_write` calls inside `with self.mcu_tmc.tmc_spi.mutex:` in both methods, matching the pattern already used by every other SPI caller in the driver (`get_register`, `set_register`, `_read_raw`, `_write_raw`).

No deadlock risk: callers such as `cmd_TMC_TUNE_PID` hold `TMC4671.mutex` (a separate object). The SPI mutex is not re-acquired inside the block.