### PR TITLE
Fix AGPI temperature sensor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,12 +8,13 @@
 ## STRUCTURE
 ```text
 tmc-4671/
-├── __init__.py         # Plugin entry point for Kalico
-├── tmc4671_regs.py     # SPI registers
-├── tmc4671_biquad.py   # Biquad filter design utilities (BiquadFilter, design functions, TMC normalisation)
-├── tmc4671.py          # Core driver implementation (PID tuning, calibration, SPI, G-code commands)
-├── pyproject.toml      # Project configuration defining the "kalico.plugins" entry-point
-└── README.md           # Hardware setup, wiring, moonraker configuration, and PID tuning instructions
+├── __init__.py                      # Plugin entry point for Kalico
+├── tmc4671_regs.py                  # SPI registers
+├── tmc4671_biquad.py                # Biquad filter design utilities (BiquadFilter, design functions, TMC normalisation)
+├── tmc4671.py                       # Core driver implementation (PID tuning, calibration, SPI, G-code commands)
+├── tmc4671_temperature_sensor.py    # [tmc4671_temperature_sensor] config section — wires AGPI thermistor into Kalico sensor infrastructure
+├── pyproject.toml                   # Project configuration defining the "kalico.plugins" entry-point
+└── README.md                        # Hardware setup, wiring, moonraker configuration, and PID tuning instructions
 ```
 
 ## WHERE TO LOOK

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Klipper driver features:
 * Optional TMC6100 output driver initialisation support (requred for the eval board, not used for OpenFFBoard or Ouroboros)
 * Virtual steps-per-revolution and microsteps. Klipper treats the TMC 4671 as if it were a conventional stepper driver, all servo activity takes place in hardware. Thus the steps and microsteps in the configuration have no particular relation to the motor, and instead are translated to position angle targets within the TMC 4671.
 * Phase current monitoring via ADC (current_ux, current_v, current_wy) — updated every 1 s in the periodic timer callback alongside STATUS_FLAGS, visible in Klipper's `get_status`
+* AGPI thermistor temperature monitoring — reads a thermistor connected to `AGPI_A` or `AGPI_B` and exposes it as a Kalico `[temperature_sensor]`
 
 ## Klipper Installation
 
@@ -99,6 +100,10 @@ spi_bus: spi1
 spi_speed: 1000000
 current_scale_ma_lsb: 1.155
 adc_temp_reg: AGPI_B
+# adc_temp_pullup_resistor: 1500   # defaults match OpenFFBoard hardware
+# adc_temp_t1: 25
+# adc_temp_r1: 10000
+# adc_temp_beta: 4300
 #diag_pin: ^tmcx:PE8       # sensorless homing: OpenFFBoard STATUS output pin
 #homing_current: 0.5       # sensorless homing: start here, increase if false triggers (see Sensorless homing section)
 run_current: 3.54
@@ -230,6 +235,30 @@ homing_mask: PID_IQ_OUTPUT_LIMIT, PID_ID_OUTPUT_LIMIT, PID_X_ERRSUM_LIMIT,
 ```
 
 `PID_IQ_TARGET_LIMIT` is the primary fast-acting stall flag. `REF_SW_R` and `REF_SW_L` allow physical limit switches to be wired to the driver board's reference switch inputs and used as endstops without an additional MCU GPIO. Most users should not need to change this.
+
+## AGPI temperature monitoring
+
+The TMC 4671 has two analog GPIO inputs (`AGPI_A`, `AGPI_B`) which can be read as a temperature sensor. On the OpenFFBoard, `AGPI_B` is connected to a 10 kΩ NTC thermistor (β = 4300) via a unity-gain buffer, with a 1.5 kΩ pulldown resistor to ground and a 2.5 V reference on the thermistor's high side.
+
+To expose it as a Kalico `[temperature_sensor]`, add `adc_temp_reg` to the `[tmc4671]` section and add a matching `[temperature_sensor]` section with `sensor_type: tmc4671_agpi <stepper>`:
+
+```ini
+[tmc4671 stepper_x]
+# ... other config ...
+adc_temp_reg: AGPI_B
+# Thermistor parameters — defaults match OpenFFBoard hardware:
+# adc_temp_pullup_resistor: 1500
+# adc_temp_t1: 25
+# adc_temp_r1: 10000
+# adc_temp_beta: 4300
+
+[temperature_sensor tmc4671_stepper_x]
+sensor_type: tmc4671_agpi stepper_x
+min_temp: 0
+max_temp: 100
+```
+
+The sensor name passed to `sensor_type` must match the stepper name (the part after `tmc4671` in the section header). Temperature is sampled every 1 s alongside the STATUS_FLAGS check. If different thermistor hardware is used, set the pullup resistor value and beta-form coefficients explicitly.
 
 ## G-code command reference
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Klipper driver features:
 * Optional TMC6100 output driver initialisation support (requred for the eval board, not used for OpenFFBoard or Ouroboros)
 * Virtual steps-per-revolution and microsteps. Klipper treats the TMC 4671 as if it were a conventional stepper driver, all servo activity takes place in hardware. Thus the steps and microsteps in the configuration have no particular relation to the motor, and instead are translated to position angle targets within the TMC 4671.
 * Phase current monitoring via ADC (current_ux, current_v, current_wy) — updated every 1 s in the periodic timer callback alongside STATUS_FLAGS, visible in Klipper's `get_status`
-* AGPI thermistor temperature monitoring — reads a thermistor connected to `AGPI_A` or `AGPI_B` and exposes it as a Kalico `[temperature_sensor]`
+* AGPI thermistor temperature monitoring — reads a thermistor connected to `AGPI_A` or `AGPI_B` and exposes it as a Kalico `[tmc4671_temperature_sensor]`
 
 ## Klipper Installation
 
@@ -240,7 +240,7 @@ homing_mask: PID_IQ_OUTPUT_LIMIT, PID_ID_OUTPUT_LIMIT, PID_X_ERRSUM_LIMIT,
 
 The TMC 4671 has two analog GPIO inputs (`AGPI_A`, `AGPI_B`) which can be read as a temperature sensor. On the OpenFFBoard, `AGPI_B` is connected to a 10 kΩ NTC thermistor (β = 4300) via a unity-gain buffer, with a 1.5 kΩ pulldown resistor to ground and a 2.5 V reference on the thermistor's high side.
 
-To expose it as a Kalico `[temperature_sensor]`, add `adc_temp_reg` to the `[tmc4671]` section and add a matching `[temperature_sensor]` section with `sensor_type: tmc4671_agpi <stepper>`:
+To expose it as a temperature sensor, add `adc_temp_reg` to the `[tmc4671]` section and add a matching `[tmc4671_temperature_sensor]` section:
 
 ```ini
 [tmc4671 stepper_x]
@@ -252,13 +252,12 @@ adc_temp_reg: AGPI_B
 # adc_temp_r1: 10000
 # adc_temp_beta: 4300
 
-[temperature_sensor tmc4671_stepper_x]
-sensor_type: tmc4671_agpi stepper_x
+[tmc4671_temperature_sensor stepper_x]
 min_temp: 0
 max_temp: 100
 ```
 
-The sensor name passed to `sensor_type` must match the stepper name (the part after `tmc4671` in the section header). Temperature is sampled every 1 s alongside the STATUS_FLAGS check. If different thermistor hardware is used, set the pullup resistor value and beta-form coefficients explicitly.
+The section name after `tmc4671_temperature_sensor` must match the stepper name (the part after `tmc4671` in the driver section header). Temperature is sampled every 1 s alongside the STATUS_FLAGS check. If different thermistor hardware is used, set the pullup resistor value and beta-form coefficients explicitly.
 
 ## G-code command reference
 

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,19 @@ function check_download {
 function link_extension {
     echo "[INSTALL] Linking extension to Klipper..."
 
+    # When targeting plugins/, remove any stale symlinks left in extras/ by a
+    # previous installation.  Kalico's _load_modules raises an error if the same
+    # module name appears in both directories, so the old extras/ links must go.
+    local extras_path="${KLIPPER_PATH}/klippy/extras"
+    if [[ "${KLIPPER_PLUGINS_PATH}" != "${extras_path}/" ]]; then
+        for f in tmc4671.py tmc4671_regs.py tmc4671_biquad.py tmc4671_temperature_sensor.py; do
+            if [[ -L "${extras_path}/${f}" ]]; then
+                echo "[INSTALL] Removing stale extras/ symlink: ${f}"
+                rm -f "${extras_path}/${f}"
+            fi
+        done
+    fi
+
     ln -srfn "${TMC4671_PATH}/tmc4671.py" "${KLIPPER_PLUGINS_PATH}/tmc4671.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_regs.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_regs.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_biquad.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_biquad.py"

--- a/install.sh
+++ b/install.sh
@@ -51,6 +51,7 @@ function link_extension {
     ln -srfn "${TMC4671_PATH}/tmc4671.py" "${KLIPPER_PLUGINS_PATH}/tmc4671.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_regs.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_regs.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_biquad.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_biquad.py"
+    ln -srfn "${TMC4671_PATH}/tmc4671_temperature_sensor.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_temperature_sensor.py"
 }
 
 function restart_klipper {

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -641,6 +641,8 @@ class TMCErrorCheck:
         # Circuit: thermistor on high side, pullup on low side → flip fraction.
         v = adc_raw - 32768
         if v <= 0:
+            logging.debug("TMC %s AGPI raw=%d (v=%d ≤ 0, no positive voltage)",
+                          self.stepper_name, adc_raw, v)
             return None
         adc_fraction = v / 32767.0
         return self._thermistor.calc_temp(1.0 - adc_fraction)
@@ -657,6 +659,7 @@ class TMCErrorCheck:
             return res
         if self.adc_temp_reg is not None:
             res['temperature'] = self.last_temp
+            res['adc_temp_raw'] = self.adc_temp
         return res
 
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -571,9 +571,11 @@ class TMCErrorCheck:
             beta = config.getfloat("adc_temp_beta", 4300., above=0.)
             self._thermistor = thermistor.Thermistor(pullup, 0.)
             self._thermistor.setup_coefficients_beta(t1, r1, beta)
-            pheaters = self.printer.load_object(config, 'heaters')
-            sensor_name = "tmc4671_agpi %s" % (self.stepper_name,)
-            pheaters.add_sensor_factory(sensor_name, lambda cfg: self)
+            # Register this object by name so tmc4671_temperature_sensor
+            # sections can look it up at connect time, regardless of section
+            # ordering in the config file.
+            obj_name = "tmc4671_agpi %s" % (self.stepper_name,)
+            self.printer.add_object(obj_name, self)
     def _make_mask(self, entries):
         mask = 0
         for f in entries:

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -535,6 +535,7 @@ class TMCErrorCheck:
         self.fields = mcu_tmc.get_fields()
         self.current_helper = current_helper
         self.check_timer = None
+        self.is_enabled = False
         self.status_warn_mask = self._make_mask(["PID_IQ_TARGET_LIMIT",
                                                  "PID_ID_TARGET_LIMIT",
                                                  "PID_V_OUTPUT_LIMIT",
@@ -609,31 +610,35 @@ class TMCErrorCheck:
             self.adc_temp = None
     def _do_periodic_check(self, eventtime):
         try:
-            self._query_status()
+            if self.is_enabled:
+                self._query_status()
             self._query_temperature(eventtime)
-            ch = self.current_helper
-            self.monitor_data['current_ux'] = ch.convert_adc_current(
-                ch._read_field("ADC_IUX"))
-            self.monitor_data['current_v'] = ch.convert_adc_current(
-                ch._read_field("ADC_IV"))
-            self.monitor_data['current_wy'] = ch.convert_adc_current(
-                ch._read_field("ADC_IWY"))
+            if self.is_enabled:
+                ch = self.current_helper
+                self.monitor_data['current_ux'] = ch.convert_adc_current(
+                    ch._read_field("ADC_IUX"))
+                self.monitor_data['current_v'] = ch.convert_adc_current(
+                    ch._read_field("ADC_IV"))
+                self.monitor_data['current_wy'] = ch.convert_adc_current(
+                    ch._read_field("ADC_IWY"))
         except self.printer.command_error as e:
             self.printer.invoke_shutdown(str(e))
             return self.printer.get_reactor().NEVER
         return eventtime + 1.
     def stop_checks(self):
-        if self.check_timer is None:
-            return
-        self.printer.get_reactor().unregister_timer(self.check_timer)
-        self.check_timer = None
-    def start_checks(self):
+        # Disable full status/current monitoring when motor is disabled.
+        # The timer itself keeps running so temperature is always polled.
+        self.is_enabled = False
+    def start_monitoring(self):
         if self.check_timer is not None:
-            self.stop_checks()
+            return
         reactor = self.printer.get_reactor()
         curtime = reactor.monotonic()
         self.check_timer = reactor.register_timer(self._do_periodic_check,
                                                   curtime + 1.)
+    def start_checks(self):
+        self.is_enabled = True
+        self.start_monitoring()
         return True
     def _convert_temp(self, adc_raw):
         # ADC u16: midscale 0x8000 = 0 V, full range ±2.5 V (single-ended,
@@ -654,7 +659,8 @@ class TMCErrorCheck:
         return 1.
     def get_status(self, eventtime=None):
         res = {'drv_status': None, 'temperature': None}
-        res.update(self.monitor_data)
+        if self.is_enabled:
+            res.update(self.monitor_data)
         if self.check_timer is None:
             return res
         if self.adc_temp_reg is not None:
@@ -1236,6 +1242,7 @@ class TMC4671:
             self.fields.PID_POSITION_TARGET.write(0)
             self.fields.MODE_MOTION.write(MotionMode.stopped_mode)
             self.init_done = True
+        self.error_helper.start_monitoring()
         enable_line.register_state_callback(self._handle_stepper_enable)
 
     def _handle_disconnect(self):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -554,19 +554,26 @@ class TMCErrorCheck:
                              }
         self.monitor_data.update({'current_ux': 0., 'current_v': 0.,
                                   'current_wy': 0.})
-        # Setup for temperature query
-        # Per the OpenFFBoard firmware source
-        #[thermistor ffboard]
-        #temperature1: 25
-        #resistance1: 10000
-        #beta: 4300
+        # Setup for temperature query via AGPI_A or AGPI_B
         self.adc_temp = None
         self.adc_temp_reg = config.getchoice("adc_temp_reg",
                                              ADC_GPIO_FIELDS,
                                              default=None)
+        self._thermistor = None
+        self.temp_callback = None
+        self.last_temp = 0.
+        self.temp_minmax = (0., 999.)
         if self.adc_temp_reg is not None:
+            pullup = config.getfloat("adc_temp_pullup_resistor", 1500.,
+                                     above=0.)
+            t1 = config.getfloat("adc_temp_t1", 25.)
+            r1 = config.getfloat("adc_temp_r1", 10000., above=0.)
+            beta = config.getfloat("adc_temp_beta", 4300., above=0.)
+            self._thermistor = thermistor.Thermistor(pullup, 0.)
+            self._thermistor.setup_coefficients_beta(t1, r1, beta)
             pheaters = self.printer.load_object(config, 'heaters')
-            pheaters.register_monitor(config)
+            sensor_name = "tmc4671_agpi %s" % (self.stepper_name,)
+            pheaters.add_sensor_factory(sensor_name, lambda cfg: self)
     def _make_mask(self, entries):
         mask = 0
         for f in entries:
@@ -586,19 +593,22 @@ class TMCErrorCheck:
             fmt = self.fields.pretty_format("STATUS_FLAGS", status)
             raise self.printer.command_error("TMC 4671 '%s' reports error: %s"
                                              % (self.stepper_name, fmt))
-    def _query_temperature(self):
-        try:
-            if self.adc_temp_reg is not None:
-                self.adc_temp = self.mcu_tmc.read_field(self.adc_temp_reg)
-                # TODO: remove this, just temp logging
-                self._convert_temp(self.adc_temp)
-        except self.printer.command_error as e:
-            # Ignore comms error for temperature
-            self.adc_temp = None
+    def _query_temperature(self, eventtime):
+        if self.adc_temp_reg is None:
             return
+        try:
+            self.adc_temp = self.mcu_tmc.read_field(self.adc_temp_reg)
+            temp = self._convert_temp(self.adc_temp)
+            if temp is not None:
+                self.last_temp = temp
+                if self.temp_callback is not None:
+                    self.temp_callback(eventtime, temp)
+        except self.printer.command_error:
+            self.adc_temp = None
     def _do_periodic_check(self, eventtime):
         try:
             self._query_status()
+            self._query_temperature(eventtime)
             ch = self.current_helper
             self.monitor_data['current_ux'] = ch.convert_adc_current(
                 ch._read_field("ADC_IUX"))
@@ -623,29 +633,28 @@ class TMCErrorCheck:
         self.check_timer = reactor.register_timer(self._do_periodic_check,
                                                   curtime + 1.)
         return True
-    def _convert_temp(self, adc):
-        v = adc - 0x7fff
-        if v < 0:
-            temp = 0.0
-        else:
-            #temp = 1500.0 * 43252.0 / float(v)
-            #temp = 64878000.0 / float(v)
-            temp = 129756000.0 / float(v)
-            #temp = (1.0/298.15) + math.log(temp / 10000.0) / 4300.0
-            temp = (0.003354016) + math.log(temp / 10000.0) / 4300.0
-            temp = 1.0 / temp
-            temp -= 273.15
-        logging.info("TMC %s temp: %g", self.stepper_name, temp)
+    def _convert_temp(self, adc_raw):
+        # ADC u16: midscale 0x8000 = 0 V, full range ±2.5 V (single-ended,
+        # INN tied to GNDA). adc_fraction = V_AGPI / 2.5 V.
+        # Circuit: thermistor on high side, pullup on low side → flip fraction.
+        v = adc_raw - 32768
+        if v <= 0:
+            return None
+        adc_fraction = v / 32767.0
+        return self._thermistor.calc_temp(1.0 - adc_fraction)
+    def setup_minmax(self, min_temp, max_temp):
+        self.temp_minmax = (min_temp, max_temp)
+    def setup_callback(self, temperature_callback):
+        self.temp_callback = temperature_callback
+    def get_report_time_delta(self):
+        return 1.
     def get_status(self, eventtime=None):
         res = {'drv_status': None, 'temperature': None}
         res.update(self.monitor_data)
         if self.check_timer is None:
             return res
-        temp = None
-        if self.adc_temp is not None:
-            # Convert it to temp here
-            temp = self._convert_temp(self.adc_temp)
-        res['temperature'] = temp
+        if self.adc_temp_reg is not None:
+            res['temperature'] = self.last_temp
         return res
 
 

--- a/tmc4671_temperature_sensor.py
+++ b/tmc4671_temperature_sensor.py
@@ -1,0 +1,64 @@
+# TMC4671 AGPI temperature sensor integration for Kalico/Klipper
+#
+# Copyright (C) 2024       Andrew McGregor <andrewmcgr@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Usage: add a [tmc4671_temperature_sensor <stepper>] section to your config.
+# The matching [tmc4671 <stepper>] section must have adc_temp_reg set.
+
+KELVIN_TO_CELSIUS = -273.15
+
+
+class TMC4671TemperatureSensor:
+    def __init__(self, config):
+        self.printer = config.get_printer()
+        self.name = config.get_name().split()[-1]
+        self.min_temp = config.getfloat(
+            "min_temp", KELVIN_TO_CELSIUS, minval=KELVIN_TO_CELSIUS
+        )
+        self.max_temp = config.getfloat(
+            "max_temp", 99999999.9, above=self.min_temp
+        )
+        self.last_temp = 0.0
+        self.measured_min = 99999999.0
+        self.measured_max = 0.0
+        pheaters = self.printer.load_object(config, "heaters")
+        pheaters.register_sensor(config, self)
+        self.printer.register_event_handler(
+            "klippy:connect", self._handle_connect
+        )
+
+    def _handle_connect(self):
+        obj_name = "tmc4671_agpi %s" % (self.name,)
+        sensor = self.printer.lookup_object(obj_name, None)
+        if sensor is None:
+            raise self.printer.config_error(
+                "tmc4671_temperature_sensor '%s': no matching [tmc4671 %s] "
+                "section with adc_temp_reg configured" % (self.name, self.name)
+            )
+        sensor.setup_minmax(self.min_temp, self.max_temp)
+        sensor.setup_callback(self._temperature_callback)
+
+    def _temperature_callback(self, read_time, temp):
+        self.last_temp = temp
+        if temp:
+            self.measured_min = min(self.measured_min, temp)
+            self.measured_max = max(self.measured_max, temp)
+
+    def get_temp(self, eventtime):
+        return self.last_temp, 0.0
+
+    def stats(self, eventtime):
+        return False, "%s: temp=%.1f" % (self.name, self.last_temp)
+
+    def get_status(self, eventtime):
+        return {
+            "temperature": round(self.last_temp, 2),
+            "measured_min_temp": round(self.measured_min, 2),
+            "measured_max_temp": round(self.measured_max, 2),
+        }
+
+
+def load_config_prefix(config):
+    return TMC4671TemperatureSensor(config)


### PR DESCRIPTION
Fixes the AGPI thermistor temperature monitoring end-to-end.

### Bugs fixed

1. **Wrong ADC constant** — `129756000.0` used where `49150500.0` is correct (R_T = 3750 × 32767 / (2.5 × v) − 1500 for the OpenFFBoard divider). Old value gave ~3× too high a thermistor resistance at 25 °C.
2. **Missing `return temp` in `_convert_temp`** — always returned `None`, so temperature was never reported.
3. **`_query_temperature` never called** — `_do_periodic_check` didn't call it.
4. **Wrong Kalico integration** — `register_monitor` is a no-op for sensing. Replaced with a proper sensor-factory registration and full sensor interface (`setup_minmax`, `setup_callback`, `get_report_time_delta`).
5. **Config-loading order race** — if `[tmc4671_temperature_sensor]` was processed before `[tmc4671]`, the sensor factory lookup failed. Fixed by registering the object by name via `printer.add_object` during config and doing the factory wiring at `klippy:connect`.
6. **Temperature only polled while motor energised** — the periodic timer was started from `_do_enable`, so temperature was never read at idle. Refactored: the timer now starts unconditionally after init completes (`start_monitoring()` called from `_handle_connect`); status-flag and current monitoring remain gated on the enable state.
7. **Stale `extras/` symlinks** — old installations left symlinks in `klippy/extras/` after Kalico added `klippy/plugins/`. Having both caused a module-loading conflict. `install.sh` now removes stale extras symlinks when installing into plugins.

### New module: `tmc4671_temperature_sensor.py`

Handles `[tmc4671_temperature_sensor <stepper>]` config sections. Looks up the sensor object at connect time (avoiding load-order races), wires the Kalico temperature callback, and registers with `pheaters` for M105/TEMPERATURE_WAIT.

### Diagnostic aid

`get_status()` now includes `adc_temp_raw` (the raw u16 ADC register value) when `adc_temp_reg` is set, visible in Mainsail/Fluidd status and via the Moonraker API. At ~25 °C with the OpenFFBoard circuit the expected raw value is ~36900; at ~41 °C ~40600.

### Config example

```ini
[tmc4671 stepper_x]
adc_temp_reg: AGPI_B
# defaults match OpenFFBoard hardware, override if needed:
# adc_temp_pullup_resistor: 1500
# adc_temp_t1: 25
# adc_temp_r1: 10000
# adc_temp_beta: 4300

[tmc4671_temperature_sensor stepper_x]
min_temp: 0
max_temp: 100
```
