### PR TITLE
Derive motor_kt and jload from motor nameplate and load parameters

### DIFF
--- a/tmc4671.py
+++ b/tmc4671.py
@@ -950,13 +950,21 @@ class TMC4671:
         self.jload  = config.getfloat('jload',  5e-5,    above=0.)
         # If load_mass is provided, compute the reflected inertia of a linear
         # load driven by a lead-screw or belt.  rotation_distance (mm/rev) is
-        # read from the stepper section and converted to m/rev; for a linear
-        # axis:  J_load = m * (pitch_m / 2π)²   [kg·m²]
+        # read from the stepper section and converted to m/rev; gear_ratio
+        # (same format as the Kalico stepper config: "N:D" pairs) reduces the
+        # effective pitch so the formula becomes:
+        #   J_load = m * (pitch_m / 2π)²   where pitch_m = rotation_distance_m / gear_ratio
         load_mass = config.getfloat('load_mass', None, minval=0.)
         if load_mass is not None:
             sconfig = config.getsection(self.stepper_name)
             rotation_distance_m = sconfig.getfloat('rotation_distance') / 1000.0
-            self.jload = load_mass * (rotation_distance_m / (2.0 * math.pi)) ** 2
+            gr_pairs = sconfig.getlists('gear_ratio', (), seps=(':', ','),
+                                        count=2, parser=float)
+            gear_ratio = 1.0
+            for n, d in gr_pairs:
+                gear_ratio *= n / d
+            effective_pitch_m = rotation_distance_m / gear_ratio
+            self.jload = load_mass * (effective_pitch_m / (2.0 * math.pi)) ** 2
         self.motor_kt = config.getfloat('motor_kt', 0.0156, above=0.)
         # If holding_current and holding_torque are both provided, derive
         # motor_kt (Kt = torque / current, N·m/A).  Both must be specified

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -948,7 +948,27 @@ class TMC4671:
         self.dead_time_v = 0.0
         self.jmotor = config.getfloat('jmotor', 8.45e-6, above=0.)
         self.jload  = config.getfloat('jload',  5e-5,    above=0.)
+        # If load_mass is provided, compute the reflected inertia of a linear
+        # load driven by a lead-screw or belt.  rotation_distance (mm/rev) is
+        # read from the stepper section and converted to m/rev; for a linear
+        # axis:  J_load = m * (pitch_m / 2π)²   [kg·m²]
+        load_mass = config.getfloat('load_mass', None, minval=0.)
+        if load_mass is not None:
+            sconfig = config.getsection(self.stepper_name)
+            rotation_distance_m = sconfig.getfloat('rotation_distance') / 1000.0
+            self.jload = load_mass * (rotation_distance_m / (2.0 * math.pi)) ** 2
         self.motor_kt = config.getfloat('motor_kt', 0.0156, above=0.)
+        # If holding_current and holding_torque are both provided, derive
+        # motor_kt (Kt = torque / current, N·m/A).  Both must be specified
+        # together.
+        holding_current = config.getfloat('holding_current', None, above=0.)
+        holding_torque  = config.getfloat('holding_torque',  None, above=0.)
+        if (holding_current is None) != (holding_torque is None):
+            raise config.error(
+                "Both 'holding_current' and 'holding_torque' must be "
+                "specified together in [%s]" % (config.get_name(),))
+        if holding_current is not None:
+            self.motor_kt = holding_torque / holding_current
         self.velocity_alpha = config.getfloat('velocity_alpha', 0.35,
                                               minval=0., maxval=1.)
         self.mcu_tmc = MCU_TMC_SPI(config, Registers, field_meta,


### PR DESCRIPTION
## Summary

Adds three new config parameters that let users specify motor and load properties directly from datasheet/measured values, rather than computing derived quantities by hand.

### `holding_current` + `holding_torque` → `motor_kt`

If both are specified, the torque constant is derived automatically:

```
Kt = holding_torque / holding_current   [N·m/A]
```

Both must be specified together; providing only one is a config error. If neither is provided, the explicit `motor_kt` parameter (default 0.0156) is used as before.

### `load_mass` → `jload`

If specified, the reflected inertia of a linear load (lead-screw or belt drive) is computed from the stepper's `rotation_distance`:

```
J_load = mass × (rotation_distance_m / 2π)²   [kg·m²]
```

`rotation_distance` (mm/rev) is read from the stepper config section. This overrides `jload`.

### Example config

```ini
[tmc4671 stepper_x]
# Motor: 0.44 N·m holding torque at 1.68 A peak → Kt = 0.44/1.68 ≈ 0.262 N·m/A
holding_current: 1.68
holding_torque: 0.44

# X carriage: 0.8 kg, rotation_distance: 40 mm → J = 0.8 × (0.04/2π)² ≈ 3.24e-5 kg·m²
load_mass: 0.8
```