### PR TITLE
Add motor and board profile config sections (foc_motor, tmc4671_board)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,9 @@ tmc-4671/
 ├── tmc4671_regs.py                  # SPI registers
 ├── tmc4671_biquad.py                # Biquad filter design utilities (BiquadFilter, design functions, TMC normalisation)
 ├── tmc4671.py                       # Core driver implementation (PID tuning, calibration, SPI, G-code commands)
+├── tmc4671_profiles.py              # Profile infrastructure: _MISSING, ConfigWithDefaults, FocProfile, BUILTIN_MOTORS, BUILTIN_BOARDS
+├── foc_motor.py                     # [foc_motor] config section — motor-specific hardware parameters (pole pairs, encoder, Kt, inertia)
+├── tmc4671_board.py                 # [tmc4671_board] config section — board-specific parameters (scaling, ADC channels, thermistor, 6100)
 ├── tmc4671_temperature_sensor.py    # [tmc4671_temperature_sensor] config section — wires AGPI thermistor into Kalico sensor infrastructure
 ├── pyproject.toml                   # Project configuration defining the "kalico.plugins" entry-point
 └── README.md                        # Hardware setup, wiring, moonraker configuration, and PID tuning instructions

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1,0 +1,318 @@
+# TMC4671 Configuration Reference
+
+All config entries for `[tmc4671 <stepper>]` sections, plus the
+`[foc_motor <name>]` and `[tmc4671_board <name>]` profile sections.
+
+Entries are grouped by what "owns" the knowledge:
+- **[Motor](#motor-specific)** — properties of the motor itself (from the datasheet or measurement)
+- **[Board](#board-specific)** — properties of the TMC4671 driver board (analog front-end, gate driver)
+- **[Instance](#instance-specific)** — properties of the specific installation (wiring, tuning, load)
+
+---
+
+## Motor-specific
+
+These entries describe the motor's physical and electrical properties. Candidates
+for `[foc_motor <name>]`.
+
+### Pole pairs and feedback source
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `n_pole_pairs` | int | `4` | — | Number of electrical pole pairs. |
+| `phi_e_selection` | int | `3` | — | Electrical angle source. `3` = ABN encoder, `5` = Hall. |
+
+### Torque constant
+
+Specify either `motor_kt` directly, or both `holding_current` and `holding_torque`
+to derive it automatically.
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `motor_kt` | float | `0.0156` | N·m/A | Motor torque constant Kt. |
+| `holding_current` | float | — | A (peak) | Holding current from datasheet. Both this and `holding_torque` must be provided together. |
+| `holding_torque` | float | — | N·m | Holding torque from datasheet. Both this and `holding_current` must be provided together. When both are given, `motor_kt = holding_torque / holding_current`. |
+
+### Inertia
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `jmotor` | float | `8.45e-6` | kg·m² | Rotor moment of inertia. |
+
+### ABN incremental encoder
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `abn_decoder_ppr` | int | `4000` | counts/rev | Encoder pulses per revolution. |
+| `abn_direction` | int | `0` | — | Invert encoder direction. `0` = normal, `1` = inverted. |
+| `abn_apol` | int | `0` | — | A-channel polarity. `0` = active high, `1` = active low. |
+| `abn_bpol` | int | `0` | — | B-channel polarity. |
+| `abn_npol` | int | `0` | — | N (index) channel polarity. |
+| `abn_use_abn_as_n` | int | `0` | — | Use ABN signal as index. |
+| `abn_cln` | int | `0` | — | Clear position on N pulse. |
+
+### AENC absolute encoder
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `aenc_deg` | int | `0` | degrees | AENC alignment offset in degrees. |
+| `aenc_ppr` | int | `0` | counts/rev | AENC pulses per revolution. |
+
+### Hall sensor
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `hall_interp` | int | `0` | — | Hall interpolation enable. |
+| `hall_sync` | int | `1` | — | Hall sync enable. |
+| `hall_polarity` | int | `0` | — | Hall sensor polarity. |
+| `hall_dir` | int | `0` | — | Hall direction inversion. |
+| `hall_dphi_max` | int | `0xAAAA` | — | Maximum Hall phase difference. |
+| `hall_phi_e_offset` | int | `0` | — | Hall electrical angle offset. |
+| `hall_blank` | int | `2` | — | Hall blanking time. |
+
+### Motor type
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `motor_type` | int | `2` | — | Motor winding type. `2` = two-phase stepper, `3` = three-phase BLDC. |
+
+---
+
+## Board-specific
+
+These entries describe the TMC4671 driver board's analog front-end, gate driver, and
+ADC channel routing. Candidates for `[tmc4671_board <name>]`.
+
+### Power and voltage measurement
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `voltage_scale_ratio` | float | `40.875` | counts/V | ADC counts per volt on the VM sense input. Default matches the OpenFFBoard resistor divider. |
+
+### Current sensing
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `current_scale_ma_lsb` | float | `1.272` | mA/LSB | Milliamps per ADC LSB. Depends on shunt resistor value and current sense amplifier gain. Default matches the OpenFFBoard. |
+
+### ADC channel routing
+
+The TMC4671 has two ADC inputs (I0, I1) that are multiplexed to the UX/V/WY current
+sense channels. These must match the board's PCB routing.
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `adc_i_ux_select` | int | `0` | — | ADC channel for phase U/X current. |
+| `adc_i_v_select` | int | `2` | — | ADC channel for phase V current. |
+| `adc_i_wy_select` | int | `1` | — | ADC channel for phase W/Y current. |
+| `adc_i0_select` | int | `0` | — | ADC I0 input selection. |
+| `adc_i1_select` | int | `1` | — | ADC I1 input selection. |
+
+### PWM and gate driver
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `pwm_freq_target` | float | `142857` | Hz | Target PWM switching frequency. Actual frequency is rounded to the nearest achievable value from the 25 MHz TMC clock. Range: 10 kHz – 150 kHz. |
+| `pwm_bbm_l` | int | `10` | counts | Bottom-side gate driver dead time (break-before-make). |
+| `pwm_bbm_h` | int | `10` | counts | Top-side gate driver dead time. |
+| `pidout_uq_ud_limits` | int | `29000` | 1/32768 Vm | Maximum output voltage from the current controllers. `32768` = 100% Vm. Also acts as anti-windup. |
+
+### TMC6100 gate driver (optional)
+
+Present only when `drv_cs_pin` is configured. These fields follow the TMC6100
+register naming convention.
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `singleline` | int | `0` | — | Single-shunt mode. |
+| `normal` | int | `1` | — | Normal mode select. |
+| `drvstrength` | int | `0` | — | Gate driver strength. |
+| `bbmclks` | int | `10` | clocks | Break-before-make clock cycles. |
+
+### AGPI temperature sensing
+
+All temperature-sensing parameters live here. In practice the thermistors used measure
+driver board output-stage temperatures (not motor winding temperatures), so this
+configuration belongs entirely to the board profile.
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `adc_temp_reg` | choice | — | — | AGPI pin used for temperature sensing: `AGPI_A` or `AGPI_B`. Omit to disable. |
+| `adc_temp_pullup_resistor` | float | `1500.0` | Ω | Pulldown resistor in the AGPI voltage divider (R_low). Default matches the OpenFFBoard. |
+| `adc_temp_t1` | float | `25.0` | °C | Thermistor reference temperature. |
+| `adc_temp_r1` | float | `10000.0` | Ω | Thermistor resistance at `adc_temp_t1`. |
+| `adc_temp_beta` | float | `4300.0` | K | Thermistor beta coefficient. |
+
+---
+
+## Instance-specific
+
+These entries are specific to a particular `[tmc4671 <stepper>]` installation and
+cannot generally be shared across motors or boards.
+
+### Profile references
+
+`[foc_motor]` and `[tmc4671_board]` sections must appear **before** any `[tmc4671]`
+section in `printer.cfg` that references them.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `motor_profile` | string | — | Name of a `[foc_motor]` section to inherit motor defaults from. |
+| `board_profile` | string | — | Name of a `[tmc4671_board]` section to inherit board defaults from. |
+
+### Hardware pins
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `cs_pin` | pin | **required** | SPI chip-select pin for the TMC4671. |
+| `drv_cs_pin` | pin | — | SPI chip-select for the TMC6100 gate driver. Omit if not present. |
+| `spi_speed` | int | `1000000` | SPI clock speed in Hz. |
+| `spi_bus` | string | — | SPI bus identifier. |
+| `spi_software_mosi_pin` | pin | — | Software SPI MOSI pin. |
+| `spi_software_miso_pin` | pin | — | Software SPI MISO pin. |
+| `spi_software_sclk_pin` | pin | — | Software SPI SCLK pin. |
+| `diag_pin` | pin | — | MCU GPIO connected to the TMC4671 DIAG output for sensorless homing. |
+
+### Current
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `run_current` | float | **required** | A | Motor current during motion. |
+| `homing_current` | float | `run_current` | A | Motor current during homing moves. |
+| `flux_current` | float | `0.0` | A | Field-weakening (D-axis) flux current. |
+
+### Load dynamics
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `jload` | float | `5e-5` | kg·m² | Load moment of inertia reflected to the motor shaft. Overridden if `load_mass` is given. |
+| `load_mass` | float | — | kg | Mass of a linear load. When given, `jload` is computed as `mass × (pitch_m / 2π)²` where `pitch_m = rotation_distance / (1000 × gear_ratio)`. |
+
+### Feedback source selection
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `position_selection` | int | `9` | — | Position feedback source. `9` = phi\_m\_abn (mechanical, ABN encoder). `0`–`8` = electrical angle sources. |
+| `velocity_selection` | int | `3` | — | Velocity feedback source. `3` = phi\_e\_abn (electrical). `9`–`12` = mechanical sources. |
+| `velocity_meter_selection` | int | `1` | — | Velocity measurement method. `0` = delta-sigma, `1` = PWM frequency meter. |
+| `mode_pid_smpl` | int | `0` | — | PID position sampling. `0` = sample at PWM frequency. |
+| `mode_pid_type` | int | `1` | — | PID algorithm. `1` = advanced PI. |
+
+### PID autotuning
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `tune_current_pid` | bool | `False` | — | Auto-compute flux/torque PID gains at startup using motor electrical parameters. Requires `_align_and_measure` to succeed. |
+| `tune_motion_pid` | bool | `False` | — | Auto-compute velocity/position PID gains at startup using inertia and bandwidth targets. |
+| `current_bandwidth` | float | `1200.0` | Hz | Target bandwidth for flux and torque current loops. Used as default for `flux_bandwidth` and `torque_bandwidth`. |
+| `flux_bandwidth` | float | `current_bandwidth` | Hz | Flux (D-axis) current loop bandwidth. |
+| `torque_bandwidth` | float | `current_bandwidth` | Hz | Torque (Q-axis) current loop bandwidth. |
+| `velocity_bandwidth` | float | `450.0` | Hz | Velocity loop bandwidth. |
+| `position_bandwidth` | float | `100.0` | Hz | Position loop bandwidth. |
+| `velocity_alpha` | float | `0.35` | — | Velocity low-pass filter coefficient (0 = no filtering, 1 = maximum). |
+
+### PID gains
+
+These can be written by `TMC_TUNE_PID` / `TMC_TUNE_MOTION_PID` and saved via `SAVE_CONFIG`.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `flux_p` | float | `9.4` | Flux (D-axis) proportional gain. |
+| `flux_i` | float | `0.087` | Flux integral gain. |
+| `current_p_n` | int | `0` | Flux P gain normalisation shift. |
+| `current_i_n` | int | `1` | Flux I gain normalisation shift. |
+| `torque_p` | float | `9.4` | Torque (Q-axis) proportional gain. |
+| `torque_i` | float | `0.087` | Torque integral gain. |
+| `velocity_p` | float | `4.5` | Velocity proportional gain. |
+| `velocity_i` | float | `0.0` | Velocity integral gain. |
+| `velocity_p_n` | int | `0` | Velocity P gain normalisation shift. |
+| `velocity_i_n` | int | `1` | Velocity I gain normalisation shift. |
+| `position_p` | float | `2.5` | Position proportional gain. |
+| `position_i` | float | `0.0` | Position integral gain. |
+| `position_p_n` | int | `0` | Position P gain normalisation shift. |
+| `position_i_n` | int | `1` | Position I gain normalisation shift. |
+
+### Feed-forward
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mode_ff` | int | `0` | Feed-forward mode. `0` = disabled. |
+| `feed_forward_velocity_gain` | float | `0.0` | Velocity feed-forward gain. |
+| `feed_forward_velocity_filter_constant` | float | `0.0` | Velocity feed-forward filter constant. |
+| `feed_forward_torque_gain` | float | `0.0` | Torque feed-forward gain. |
+| `feed_forward_torque_filter_constant` | float | `0.0` | Torque feed-forward filter constant. |
+
+### Biquad filters
+
+Four independent second-order filters — one per control loop. Targets: `flux`, `torque`,
+`velocity`, `position`.
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `biquad_{target}_filter` | choice | `lpf` | — | Filter type: `lpf` (low-pass), `notch`, `apf` (all-pass). |
+| `biquad_{target}_frequency` | float | **required** | Hz | Cutoff or center frequency. Required unless `tune_current_pid` (for flux/torque) or `tune_motion_pid` (for velocity) is `True`, in which case it defaults to `0` (disabled). |
+| `biquad_{target}_slope` | float | `0.707` | — | Q factor / slope (√½ for Butterworth response). |
+
+### Position and velocity limits
+
+| Key | Type | Default | Unit | Description |
+|-----|------|---------|------|-------------|
+| `pid_position_limit_low` | int | `-268435456` | counts | Lower position limit. |
+| `pid_position_limit_high` | int | `268435456` | counts | Upper position limit. |
+| `pid_velocity_limit` | int | `268435456` | RPM | Velocity magnitude limit. |
+
+---
+
+## Design notes — profile inheritance
+
+### `[foc_motor <name>]` example
+
+```ini
+[foc_motor LDO_2504b-EN1000]
+motor_type: 2
+n_pole_pairs: 50
+holding_current: 1.0
+holding_torque: 0.165
+jmotor: 7.6e-7
+abn_decoder_ppr: 1000
+```
+
+### `[tmc4671_board OpenFFBoard]` example
+
+The `OpenFFBoard` board profile is also available as a built-in — you can write
+`board_profile: OpenFFBoard` without defining a config section.
+
+```ini
+[tmc4671_board OpenFFBoard]
+voltage_scale_ratio: 40.875
+current_scale_ma_lsb: 1.272
+adc_i_ux_select: 0
+adc_i_v_select: 2
+adc_i_wy_select: 1
+adc_temp_reg: AGPI_B
+adc_temp_pullup_resistor: 1500
+adc_temp_t1: 25
+adc_temp_r1: 10000
+adc_temp_beta: 4300
+```
+
+### `[tmc4671 stepper_x]` with profiles
+
+Profile sections must appear **before** the `[tmc4671]` section that references them.
+
+```ini
+[foc_motor LDO_2504b-EN1000]
+# ... motor parameters ...
+
+[tmc4671_board OpenFFBoard]
+# ... or omit and rely on the built-in ...
+
+[tmc4671 stepper_x]
+motor_profile: LDO_2504b-EN1000
+board_profile: OpenFFBoard
+cs_pin: ...
+run_current: 0.8
+load_mass: 0.6
+tune_current_pid: True
+tune_motion_pid: True
+```

--- a/foc_motor.py
+++ b/foc_motor.py
@@ -1,0 +1,99 @@
+# TMC4671 motor profile config section
+#
+# Copyright (C) 2024  Andrew McGregor <andrewmcgr@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Handles [foc_motor <name>] config sections.  A motor profile captures all
+# motor-specific hardware parameters (pole pairs, encoder geometry, Hall
+# sensor settings, motor Kt, rotor inertia) so that multiple [tmc4671]
+# instances driving the same motor model can share a single definition.
+#
+# Usage in printer.cfg:
+#
+#   [foc_motor nema17_1]
+#   n_pole_pairs: 50
+#   abn_decoder_ppr: 4000
+#   motor_kt: 0.022
+#   jmotor: 8.45e-6
+#
+#   [tmc4671 stepper_x]
+#   motor_profile: nema17_1
+#   ...
+
+from .tmc4671_profiles import FocProfile
+
+
+class FocMotor(FocProfile):
+    """Motor profile: captures motor-specific hardware parameters.
+
+    All fields are optional.  Unspecified fields fall through to the
+    hardcoded defaults in tmc4671.py, exactly as if the profile were absent.
+
+    ``motor_kt`` may be specified directly, **or** derived from
+    ``holding_current`` + ``holding_torque`` (Kt = torque / current).
+    Specifying both ``motor_kt`` and the holding pair is an error.
+    """
+
+    ALLOWED = [
+        # Motor electrical / mechanical type
+        ('motor_type',          'int'),    # 2 = two-phase stepper (default), 3 = BLDC
+        ('n_pole_pairs',        'int'),    # number of electrical pole pairs
+
+        # Motor torque constant
+        ('motor_kt',            'float'),  # N·m / A (direct)
+        ('holding_current',     'float'),  # A  ─┐ alternative: derive Kt
+        ('holding_torque',      'float'),  # N·m ─┘
+
+        # Rotor inertia
+        ('jmotor',              'float'),  # kg·m²
+
+        # ABN incremental encoder
+        ('abn_decoder_ppr',     'int'),    # pulses per revolution
+        ('abn_direction',       'bool'),   # reverse encoder direction
+        ('abn_apol',            'bool'),   # A-channel polarity inversion
+        ('abn_bpol',            'bool'),   # B-channel polarity inversion
+        ('abn_npol',            'bool'),   # N-channel polarity inversion
+        ('abn_use_abn_as_n',    'bool'),   # use ABN as N
+        ('abn_cln',             'bool'),   # ABN clear-on-N
+
+        # Analog encoder (AENC / Hall)
+        ('aenc_deg',            'int'),    # 1 = 120°, 2 = 60° analogue Hall
+        ('aenc_ppr',            'int'),    # analogue encoder PPR
+
+        # Digital Hall sensor
+        ('hall_interp',         'bool'),   # Hall interpolation
+        ('hall_sync',           'bool'),   # sync Hall to PWM
+        ('hall_polarity',       'bool'),   # invert Hall polarity
+        ('hall_dir',            'bool'),   # reverse Hall direction
+        ('hall_dphi_max',       'int'),    # max angular step between Hall edges
+        ('hall_phi_e_offset',   'int'),    # electrical angle offset
+        ('hall_blank',          'int'),    # Hall blank time (PWM cycles)
+
+        # Feedback selection
+        ('phi_e_selection',     'int'),    # 3 = ABN, 5 = Hall
+    ]
+
+    def _validate(self, config):
+        hc = self._values.get('holding_current')
+        ht = self._values.get('holding_torque')
+        # Both or neither must be given.
+        if (hc is None) != (ht is None):
+            raise config.error(
+                "'holding_current' and 'holding_torque' must be specified "
+                "together in [%s]" % (self._name,))
+        if hc is not None:
+            if 'motor_kt' in self._values:
+                raise config.error(
+                    "Cannot specify both 'motor_kt' and "
+                    "'holding_current'/'holding_torque' in [%s]"
+                    % (self._name,))
+            # Derive Kt and remove the raw pair from the profile dict so that
+            # ConfigWithDefaults only sees 'motor_kt'.
+            self._values['motor_kt'] = ht / hc
+            del self._values['holding_current']
+            del self._values['holding_torque']
+
+
+def load_config_prefix(config):
+    return FocMotor(config)

--- a/install.sh
+++ b/install.sh
@@ -53,7 +53,7 @@ function link_extension {
     # module name appears in both directories, so the old extras/ links must go.
     local extras_path="${KLIPPER_PATH}/klippy/extras"
     if [[ "${KLIPPER_PLUGINS_PATH}" != "${extras_path}/" ]]; then
-        for f in tmc4671.py tmc4671_regs.py tmc4671_biquad.py tmc4671_temperature_sensor.py; do
+        for f in tmc4671.py tmc4671_regs.py tmc4671_biquad.py tmc4671_temperature_sensor.py tmc4671_profiles.py foc_motor.py tmc4671_board.py; do
             if [[ -L "${extras_path}/${f}" ]]; then
                 echo "[INSTALL] Removing stale extras/ symlink: ${f}"
                 rm -f "${extras_path}/${f}"
@@ -65,6 +65,9 @@ function link_extension {
     ln -srfn "${TMC4671_PATH}/tmc4671_regs.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_regs.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_biquad.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_biquad.py"
     ln -srfn "${TMC4671_PATH}/tmc4671_temperature_sensor.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_temperature_sensor.py"
+    ln -srfn "${TMC4671_PATH}/tmc4671_profiles.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_profiles.py"
+    ln -srfn "${TMC4671_PATH}/foc_motor.py" "${KLIPPER_PLUGINS_PATH}/foc_motor.py"
+    ln -srfn "${TMC4671_PATH}/tmc4671_board.py" "${KLIPPER_PLUGINS_PATH}/tmc4671_board.py"
 }
 
 function restart_klipper {

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -26,6 +26,9 @@ from .tmc4671_biquad import (
     biquad_lpf_tmc, biquad_lpf, biquad_notch, biquad_apf,
     biquad_Z_tmc, biquad_tmc
 )
+from .tmc4671_profiles import (
+    ConfigWithDefaults, BUILTIN_MOTORS, BUILTIN_BOARDS
+)
 
 # The 4671 has a 25 MHz external clock
 TMC_FREQUENCY=25000000.
@@ -904,6 +907,37 @@ class MCU_TMC_SPI:
             "(last read %x)" % (self.name, reg, v))
 
 ######################################################################
+# Profile resolution helper
+######################################################################
+
+
+def _resolve_profile(printer, config, key, builtin_db, section_prefix):
+    """Look up a named motor or board profile and return its values dict.
+
+    Resolution order:
+      1. A ``[<section_prefix> <name>]`` config section present in printer.cfg
+         (registered as a printer object by foc_motor.py / tmc4671_board.py).
+      2. An entry in *builtin_db* (e.g. ``BUILTIN_BOARDS['OpenFFBoard']``).
+
+    Returns an empty dict when *key* is not present in the instance config.
+    """
+    name = config.get(key, None)
+    if name is None:
+        return {}
+    section_name = "%s %s" % (section_prefix, name)
+    obj = printer.lookup_object(section_name, None)
+    if obj is not None:
+        return obj.get_values()
+    if name in builtin_db:
+        return builtin_db[name]
+    raise config.error(
+        "Profile '%s' not found for [%s]. "
+        "Available built-in profiles: %s"
+        % (name, config.get_name(),
+           ', '.join(builtin_db.keys()) or '(none)'))
+
+
+######################################################################
 # Main driver class
 ######################################################################
 
@@ -913,6 +947,19 @@ class TMC4671:
         self.printer = config.get_printer()
         self.stepper_name = ' '.join(config.get_name().split()[1:])
         self.name = config.get_name().split()[-1]
+        # Resolve motor and board profiles before any other config reads so
+        # that ConfigWithDefaults can inject profile defaults transparently.
+        motor_values = _resolve_profile(
+            self.printer, config, 'motor_profile', BUILTIN_MOTORS, 'foc_motor')
+        board_values = _resolve_profile(
+            self.printer, config, 'board_profile', BUILTIN_BOARDS, 'tmc4671_board')
+        overlap = set(motor_values) & set(board_values)
+        if overlap:
+            raise config.error(
+                "Motor and board profiles both define: %s in [%s]"
+                % (', '.join(sorted(overlap)), config.get_name()))
+        if motor_values or board_values:
+            config = ConfigWithDefaults(config, motor_values, board_values)
         self.mutex = self.printer.get_reactor().mutex()
         self.init_done = False
         self.alignment_done = False
@@ -1100,7 +1147,7 @@ class TMC4671:
         set_config_field(config, "PWM_BBM_H", 10)
         set_config_field(config, "PWM_CHOP", 7)
         set_config_field(config, "PWM_SV", 1)
-        set_config_field(config, "MOTOR_TYPE", 3)
+        set_config_field(config, "MOTOR_TYPE", 2)
         set_config_field(config, "N_POLE_PAIRS", 4)
         set_config_field(config, "ADC_I_UX_SELECT", 0)
         set_config_field(config, "ADC_I_V_SELECT", 2)

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1228,7 +1228,8 @@ class TMC4671:
                 default="lpf",
             )
             freq_kwargs = {}
-            if (self.tune_current_pid and target in ('flux', 'torque')) or \
+            if target == 'position' or \
+               (self.tune_current_pid and target in ('flux', 'torque')) or \
                (self.tune_motion_pid and target == 'velocity'):
                 freq_kwargs['default'] = 0.0
             freq = config.getfloat(

--- a/tmc4671_board.py
+++ b/tmc4671_board.py
@@ -1,0 +1,79 @@
+# TMC4671 board profile config section
+#
+# Copyright (C) 2024  Andrew McGregor <andrewmcgr@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Handles [tmc4671_board <name>] config sections.  A board profile captures
+# all PCB-specific parameters (voltage/current scaling, ADC channel
+# assignments, dead-time settings, TMC6100 gate-driver settings, and the
+# AGPI thermistor configuration) so that multiple [tmc4671] instances on the
+# same board can share a single definition.
+#
+# Usage in printer.cfg:
+#
+#   [tmc4671_board myboard]
+#   voltage_scale_ratio: 40.875
+#   current_scale_ma_lsb: 1.272
+#   adc_i_ux_select: 0
+#   adc_i_v_select: 2
+#   adc_i_wy_select: 1
+#
+#   [tmc4671 stepper_x]
+#   board_profile: myboard
+#   ...
+#
+# The built-in profile name 'OpenFFBoard' is available without any
+# [tmc4671_board] section in printer.cfg:
+#
+#   [tmc4671 stepper_x]
+#   board_profile: OpenFFBoard
+#   ...
+
+from .tmc4671_profiles import FocProfile
+
+
+class FocBoard(FocProfile):
+    """Board profile: captures PCB-specific hardware parameters.
+
+    All fields are optional.  Unspecified fields fall through to the
+    hardcoded defaults in tmc4671.py.
+    """
+
+    ALLOWED = [
+        # Voltage and current scaling
+        ('voltage_scale_ratio',      'float'),  # V_bus / ADC_full_scale
+        ('current_scale_ma_lsb',     'float'),  # mA per ADC LSB
+
+        # PWM frequency
+        ('pwm_freq_target',          'float'),  # Hz; actual freq rounded to chip granularity
+
+        # ADC current channel assignment (which ADC input maps to which phase)
+        ('adc_i_ux_select',          'int'),    # phase U/X ADC channel
+        ('adc_i_v_select',           'int'),    # phase V ADC channel
+        ('adc_i_wy_select',          'int'),    # phase W/Y ADC channel
+
+        # PWM dead-time (break-before-make) settings
+        ('pwm_bbm_l',                'int'),    # low-side BBM time (PWM cycles)
+        ('pwm_bbm_h',                'int'),    # high-side BBM time (PWM cycles)
+
+        # Voltage output limit (32768 = Vm); also acts as anti-windup
+        ('pidout_uq_ud_limits',      'int'),
+
+        # TMC6100 gate driver (only relevant when drv_cs_pin is set)
+        ('singleline',               'bool'),   # single-line SPI mode
+        ('normal',                   'bool'),   # normal (not stealth) mode
+        ('drvstrength',              'int'),    # gate drive strength (0-3)
+        ('bbmclks',                  'int'),    # BBM clock cycles
+
+        # AGPI thermistor configuration
+        ('adc_temp_reg',             'str'),    # 'AGPI_A' or 'AGPI_B'
+        ('adc_temp_pullup_resistor', 'float'),  # Ω — pull-down to GND
+        ('adc_temp_t1',              'float'),  # °C reference temperature
+        ('adc_temp_r1',              'float'),  # Ω thermistor resistance at t1
+        ('adc_temp_beta',            'float'),  # thermistor beta coefficient
+    ]
+
+
+def load_config_prefix(config):
+    return FocBoard(config)

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -151,24 +151,39 @@ class FocProfile:
 # ---------------------------------------------------------------------------
 
 BUILTIN_MOTORS = {
-    # Populated as motors are characterised and contributed.
+    'LDO_2504b-EN1000': {
+        'motor_type':       2,
+        'n_pole_pairs':     50,
+        'motor_kt':         0.022,   # holding_torque 0.055 Nm / holding_current 2.5 A
+        'jmotor':           8.45e-6,
+        'abn_decoder_ppr':  4000,
+    },
 }
 
 BUILTIN_BOARDS = {
     'OpenFFBoard': {
-        # Voltage and current scaling
         'voltage_scale_ratio':      40.875,
-        'current_scale_ma_lsb':     1.272,
-        # ADC current channel assignment
+        'current_scale_ma_lsb':     1.155,
         'adc_i_ux_select':          0,
         'adc_i_v_select':           2,
         'adc_i_wy_select':          1,
-        # AGPI_B thermistor: 10 kΩ NTC, β = 4300, via 2.5 V ref and 1.5 kΩ
-        # pull-down, unity-gain buffer into AGPI_B.
+        'pwm_bbm_l':                9,
+        'pwm_bbm_h':                9,
+        'pidout_uq_ud_limits':      31440,
         'adc_temp_reg':             'AGPI_B',
         'adc_temp_pullup_resistor': 1500.0,
         'adc_temp_t1':              25.0,
         'adc_temp_r1':              10000.0,
         'adc_temp_beta':            4300.0,
+    },
+    'Ouroboros': {
+        'voltage_scale_ratio':  40.875,
+        'current_scale_ma_lsb': 1.272,
+        'adc_i_ux_select':      0,
+        'adc_i_v_select':       2,
+        'adc_i_wy_select':      1,
+        'pwm_bbm_l':            10,
+        'pwm_bbm_h':            10,
+        'pidout_uq_ud_limits':  31440,
     },
 }

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -92,22 +92,13 @@ class ConfigWithDefaults:
         return self._config.get(name, *args, **kwargs)
 
     # ------------------------------------------------------------------
-    # Pass-through methods (not intercepted)
+    # Pass-through: delegate any attribute not explicitly defined above
+    # to the underlying config object.  This covers has_section(),
+    # getlists(), getsection(), get_name(), get_printer(), error(), and
+    # anything else Klipper may call on the config object.
 
-    def getlists(self, name, *args, **kwargs):
-        return self._config.getlists(name, *args, **kwargs)
-
-    def getsection(self, name):
-        return self._config.getsection(name)
-
-    def get_name(self):
-        return self._config.get_name()
-
-    def get_printer(self):
-        return self._config.get_printer()
-
-    def error(self, msg):
-        return self._config.error(msg)
+    def __getattr__(self, name):
+        return getattr(self._config, name)
 
 
 class FocProfile:

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -1,0 +1,183 @@
+# TMC4671 motor and board profile infrastructure
+#
+# Copyright (C) 2024  Andrew McGregor <andrewmcgr@gmail.com>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+#
+# Provides:
+#   _MISSING          - sentinel for "key not in profile"
+#   ConfigWithDefaults - config wrapper that injects profile defaults
+#   FocProfile        - base class for FocMotor / FocBoard
+#   BUILTIN_MOTORS    - dict of named built-in motor profiles
+#   BUILTIN_BOARDS    - dict of named built-in board profiles
+
+_MISSING = object()
+
+
+class ConfigWithDefaults:
+    """Thin Klipper config wrapper that injects motor/board profile defaults.
+
+    All standard config getters are intercepted.  When a caller supplies a
+    *default* argument (positional or keyword) and the profile contains a
+    value for that key, the profile value replaces the caller's default.
+    Instance-section values always win (Klipper reads the file first and only
+    falls back to the default when the option is absent).
+
+    Key matching rules
+    ------------------
+    * Direct lookup: ``voltage_scale_ratio`` → matches ``voltage_scale_ratio``
+      in the profile dict.
+    * Prefix stripping: ``set_config_field(config, "N_POLE_PAIRS", 4)``
+      generates config key ``foc_n_pole_pairs`` (FieldHelper adds prefix
+      ``foc_``).  ``_lookup`` strips ``foc_`` and matches ``n_pole_pairs``
+      in the motor profile.  The same logic applies to the ``drv_`` prefix
+      used by the TMC6100 FieldHelper.
+    """
+
+    def __init__(self, config, *profile_dicts):
+        self._config = config
+        # Earlier dicts (motor) take priority; merge in reverse so higher
+        # priority wins.
+        self._defaults = {}
+        for d in reversed(profile_dicts):
+            self._defaults.update(d)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _lookup(self, name):
+        name_lower = name.lower()
+        if name_lower in self._defaults:
+            return self._defaults[name_lower]
+        for prefix in ("foc_", "drv_"):
+            if name_lower.startswith(prefix):
+                stripped = name_lower[len(prefix):]
+                if stripped in self._defaults:
+                    return self._defaults[stripped]
+        return _MISSING
+
+    def _inject(self, name, args, kwargs):
+        """Replace the caller's default with the profile value if present."""
+        val = self._lookup(name)
+        if val is _MISSING:
+            return args, kwargs
+        if 'default' in kwargs:
+            kwargs = dict(kwargs, default=val)
+        elif args:
+            args = (val,) + args[1:]
+        # No default supplied → required field; do not inject.
+        return args, kwargs
+
+    # ------------------------------------------------------------------
+    # Intercepted config getters
+
+    def getfloat(self, name, *args, **kwargs):
+        args, kwargs = self._inject(name, args, kwargs)
+        return self._config.getfloat(name, *args, **kwargs)
+
+    def getint(self, name, *args, **kwargs):
+        args, kwargs = self._inject(name, args, kwargs)
+        return self._config.getint(name, *args, **kwargs)
+
+    def getboolean(self, name, *args, **kwargs):
+        args, kwargs = self._inject(name, args, kwargs)
+        return self._config.getboolean(name, *args, **kwargs)
+
+    def getchoice(self, name, *args, **kwargs):
+        args, kwargs = self._inject(name, args, kwargs)
+        return self._config.getchoice(name, *args, **kwargs)
+
+    def get(self, name, *args, **kwargs):
+        args, kwargs = self._inject(name, args, kwargs)
+        return self._config.get(name, *args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Pass-through methods (not intercepted)
+
+    def getlists(self, name, *args, **kwargs):
+        return self._config.getlists(name, *args, **kwargs)
+
+    def getsection(self, name):
+        return self._config.getsection(name)
+
+    def get_name(self):
+        return self._config.get_name()
+
+    def get_printer(self):
+        return self._config.get_printer()
+
+    def error(self, msg):
+        return self._config.error(msg)
+
+
+class FocProfile:
+    """Base class for motor and board profile config sections.
+
+    Subclasses define ``ALLOWED``: a list of ``(key, type_str)`` pairs where
+    *key* is the natural name (no prefix) used in the profile section and
+    *type_str* is one of ``'float'``, ``'int'``, ``'bool'``, ``'str'``.
+
+    All allowed keys are optional in the profile section; unspecified keys are
+    simply absent from ``get_values()``, allowing the hardcoded defaults in
+    ``tmc4671.py`` to apply.
+    """
+
+    ALLOWED = []  # subclasses define this
+
+    def __init__(self, config):
+        self._name = config.get_name()
+        self._config = config
+        self._values = {}
+        for key, type_str in self.ALLOWED:
+            val = self._read_one(config, key, type_str)
+            if val is not _MISSING:
+                self._values[key] = val
+        self._validate(config)
+
+    def _read_one(self, config, key, type_str):
+        if type_str == 'float':
+            val = config.getfloat(key, None)
+        elif type_str == 'int':
+            val = config.getint(key, None)
+        elif type_str == 'bool':
+            val = config.getboolean(key, None)
+        elif type_str == 'str':
+            val = config.get(key, None)
+        else:
+            return _MISSING
+        return _MISSING if val is None else val
+
+    def _validate(self, config):
+        pass  # override in subclasses
+
+    def get_values(self):
+        """Return a copy of the resolved profile dict."""
+        return dict(self._values)
+
+
+# ---------------------------------------------------------------------------
+# Built-in profiles
+# ---------------------------------------------------------------------------
+
+BUILTIN_MOTORS = {
+    # Populated as motors are characterised and contributed.
+}
+
+BUILTIN_BOARDS = {
+    'OpenFFBoard': {
+        # Voltage and current scaling
+        'voltage_scale_ratio':      40.875,
+        'current_scale_ma_lsb':     1.272,
+        # ADC current channel assignment
+        'adc_i_ux_select':          0,
+        'adc_i_v_select':           2,
+        'adc_i_wy_select':          1,
+        # AGPI_B thermistor: 10 kΩ NTC, β = 4300, via 2.5 V ref and 1.5 kΩ
+        # pull-down, unity-gain buffer into AGPI_B.
+        'adc_temp_reg':             'AGPI_B',
+        'adc_temp_pullup_resistor': 1500.0,
+        'adc_temp_t1':              25.0,
+        'adc_temp_r1':              10000.0,
+        'adc_temp_beta':            4300.0,
+    },
+}


### PR DESCRIPTION
## Summary

Introduces a profile system so motor and board hardware parameters can be defined once in named config sections and reused across multiple `[tmc4671]` instances.

## New files

### `tmc4671_profiles.py`
- `_MISSING` sentinel
- `ConfigWithDefaults` — thin wrapper around Klipper's config object; snip injects profile values as defaults for subsequent config reads without touching existing TMC4671 code
- `FocProfile` — base class for typed profile sections (reads allowed keys, validates types)
- `BUILTIN_MOTORS = {}` — populated as motors are characterised
- `BUILTIN_BOARDS = {'OpenFFBoard': {...}}` — OpenFFBoard voltage/current scaling and AGPI thermistor parameters pre-populated

### `foc_motor.py`
`[foc_motor <name>]` config section covering motor-specific parameters:
- Pole pairs, motor type, torque constant (`motor_kt` or derived from `holding_current` + `holding_torque`)
- Rotor inertia
- ABN incremental encoder (PPR, direction, polarity, index options)
- AENC absolute encoder (`aenc_deg`, `aenc_ppr`)
- Hall sensor (interpolation, sync, polarity, direction, blanking, offset)
- `phi_e_selection`

### `tmc4671_board.py`
`[tmc4671_board <name>]` config section covering board-specific parameters:
- Voltage and current scaling (`voltage_scale_ratio`, `current_scale_ma_lsb`)
- ADC channel routing (`adc_i_ux/v/wy_select`)
- PWM frequency and gate-driver dead time (`pwm_bbm_l/h`, `pidout_uq_ud_limits`)
- TMC6100 gate driver options (`singleline`, `normal`, `drvstrength`, `bbmclks`)
- All AGPI temperature sensing parameters (`adc_temp_reg`, `adc_temp_pullup_resistor`, `adc_temp_t1`, `adc_temp_r1`, `adc_temp_beta`)

## Changes to existing files

### `tmc4671.py`
- Import `ConfigWithDefaults`, `BUILTIN_MOTORS`, `BUILTIN_BOARDS`
- `_resolve_profile()` helper resolves a named profile via `printer.lookup_object()` first, then the built-in dict
- `TMC4671.__init__`: resolve `motor_profile` and `board_profile` at the top and wrap `config` with `ConfigWithDefaults` when profiles are present; snip raises `config.error` on key overlap between motor and board profiles
- Fix `MOTOR_TYPE` default: `3` (three-phase BLDC) → `2` (two-phase stepper)

### `install.sh`
- Three new `ln -srfn` lines for the new modules
- Stale-extras symlink cleanup list extended to include the new files

### `AGENTS.md`
- STRUCTURE section updated with entries for the three new files

### `docs/config-reference.md`
- Add AENC encoder section to motor table
- Update profile-reference key names: `motor`/`board` → `motor_profile`/`board_profile`
- Add section-ordering note (profiles must precede `[tmc4671]` sections)
- Remove all 'planned' language; snip update examples to use current key names

## Usage example

```ini
[foc_motor LDO_2504b-EN1000]
motor_type: 2
n_pole_pairs: 50
holding_current: 1.0
holding_torque: 0.165
jmotor: 7.6e-7
abn_decoder_ppr: 1000

# OpenFFBoard is also available as a built-in — no section needed
[tmc4671_board OpenFFBoard]
voltage_scale_ratio: 40.875
current_scale_ma_lsb: 1.272
adc_i_ux_select: 0
adc_i_v_select: 2
adc_i_wy_select: 1
adc_temp_reg: AGPI_B

[tmc4671 stepper_x]
motor_profile: LDO_2504b-EN1000
board_profile: OpenFFBoard
cs_pin: ...
run_current: 0.8
load_mass: 0.6
tune_current_pid: True
tune_motion_pid: True
```

## Backward compatibility

All new config keys (`motor_profile`, `board_profile`) are optional. Existing configs with no profile references are entirely unaffected — `ConfigWithDefaults` is only instantiated when at least one profile is named.