### PR TITLE
Set Ouroboros BBM dead time to 9

### DIFF
--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -182,8 +182,8 @@ BUILTIN_BOARDS = {
         'adc_i_ux_select':      0,
         'adc_i_v_select':       2,
         'adc_i_wy_select':      1,
-        'pwm_bbm_l':            10,
-        'pwm_bbm_h':            10,
+        'pwm_bbm_l':            9,
+        'pwm_bbm_h':            9,
         'pidout_uq_ud_limits':  31440,
     },
 }


### PR DESCRIPTION
Adjusts `pwm_bbm_l` and `pwm_bbm_h` for the Ouroboros board profile from 10 to 9, matching the OpenFFBoard value.