### PR TITLE
Fix velocity_p formula and correct LDO motor Kt

### DIFF
--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1559,7 +1559,11 @@ class TMC4671:
         omega_bw = 2.0 * math.pi * bandwidth
         npoles = self.vpoles()
         j_total = self.jmotor + self.jload
-        velocity_p = omega_bw * (2.0 * math.pi * j_total) / (60.0 * npoles * self.motor_kt)
+        # velocity_p units: the TMC4671 applies PID_VELOCITY_P directly to the
+        # ERPM error value with no implicit unit conversion.  omega_bw already
+        # converts the bandwidth spec to rad/s; introducing a further 2π/60
+        # RPM→rad/s factor here would make the gain ~10× too small.
+        velocity_p = omega_bw * j_total / (npoles * self.motor_kt)
         nsmpl = self.fields.MODE_PID_SMPL.read()
         f_loop = self.pwmfreq / (nsmpl + 1)
         velocity_i = (1.0 - self.velocity_alpha) * omega_bw / (4.0 * f_loop)

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -154,7 +154,7 @@ BUILTIN_MOTORS = {
     'LDO_2504b-EN1000': {
         'motor_type':       2,
         'n_pole_pairs':     50,
-        'motor_kt':         0.022,   # holding_torque 0.055 Nm / holding_current 2.5 A
+        'motor_kt':         0.216,   # holding_torque 0.54 Nm / holding_current 2.5 A
         'jmotor':           8.45e-6,
         'abn_decoder_ppr':  4000,
     },


### PR DESCRIPTION
## Changes

### Fix spurious 2π/60 factor in `_calc_velocity_pid`

The previous formula:
```python
velocity_p = omega_bw * (2.0 * math.pi * j_total) / (60.0 * npoles * self.motor_kt)
```

contained an extra `2π/60` factor intended as an RPM→rad/s conversion. However, the TMC4671 applies `PID_VELOCITY_P` directly to the raw ERPM error value — no implicit unit conversion happens in the chip. The `omega_bw = 2π × bandwidth` term already converts the bandwidth spec from Hz to rad/s; snip introducing a second RPM→rad/s factor makes the gain roughly 10× too small when the correct motor Kt is used.

Corrected formula:
```python
velocity_p = omega_bw * j_total / (npoles * self.motor_kt)
```

**Practical impact**: a correct `motor_kt = 0.22 N·m/A` previously produced a Q8.8 gain of 0 (rounded down), making velocity control sloppy. With this fix it produces Q8.8 = 1, which matches the empirically working value previously only achieved by accident with an incorrect (10× low) Kt.

### Correct LDO_2504b-EN1000 motor Kt

`motor_kt` corrected from `0.022` to `0.216 N·m/A` (holding torque 0.54 Nm / holding current 2.5 A). The previous value had a comment citing 0.055 Nm / 2.5 A — both the torque figure and the resulting Kt were wrong.