### PR TITLE
Add Ouroboros_Stepper built-in motor profile

### DIFF
--- a/foc_motor.py
+++ b/foc_motor.py
@@ -44,6 +44,7 @@ class FocMotor(FocProfile):
         ('motor_kt',            'float'),  # N·m / A (direct)
         ('holding_current',     'float'),  # A  ─┐ alternative: derive Kt
         ('holding_torque',      'float'),  # N·m ─┘
+        ('rated_current',       'float'),  # A RMS; driver converts to peak (× √2) for run_current default
 
         # Rotor inertia
         ('jmotor',              'float'),  # kg·m²

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -439,8 +439,15 @@ class CurrentHelper:
         self.name = config.get_name().split()[-1]
         self.mcu_tmc = mcu_tmc
         self.fields = FieldProxy(mcu_tmc.get_fields(), mcu_tmc)
-        self.run_current = config.getfloat('run_current',
-                                      above=0., maxval=MAX_CURRENT)
+        rated_current = config.getfloat('rated_current', None, above=0.,
+                                        maxval=MAX_CURRENT)
+        if rated_current is not None:
+            default_run = rated_current * math.sqrt(2)
+            self.run_current = config.getfloat('run_current', default_run,
+                                               above=0., maxval=MAX_CURRENT)
+        else:
+            self.run_current = config.getfloat('run_current',
+                                               above=0., maxval=MAX_CURRENT)
         self.homing_current = config.getfloat('homing_current', above=0.,
                                               maxval=MAX_CURRENT,
                                               default=self.run_current)

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -158,6 +158,14 @@ BUILTIN_MOTORS = {
         'jmotor':           8.45e-6,
         'abn_decoder_ppr':  4000,
     },
+    'Ouroboros_Stepper': {
+        'motor_type':       2,
+        'n_pole_pairs':     50,
+        'motor_kt':         0.22,    # holding_torque 0.55 Nm / holding_current 2.5 A
+        'jmotor':           8.2e-6,
+        'abn_decoder_ppr':  4000,
+        'abn_direction':    True,
+    },
 }
 
 BUILTIN_BOARDS = {

--- a/tmc4671_profiles.py
+++ b/tmc4671_profiles.py
@@ -157,6 +157,7 @@ BUILTIN_MOTORS = {
         'motor_kt':         0.216,   # holding_torque 0.54 Nm / holding_current 2.5 A
         'jmotor':           8.45e-6,
         'abn_decoder_ppr':  4000,
+        'rated_current':    2.5,     # A RMS
     },
     'Ouroboros_Stepper': {
         'motor_type':       2,
@@ -165,6 +166,7 @@ BUILTIN_MOTORS = {
         'jmotor':           8.2e-6,
         'abn_decoder_ppr':  4000,
         'abn_direction':    True,
+        'rated_current':    2.5,     # A RMS
     },
 }
 


### PR DESCRIPTION
Adds a built-in `[foc_motor]` profile for the Ouroboros stepper motor.

Can be referenced in printer.cfg as:

```ini
[tmc4671 stepper_x]
motor_profile: Ouroboros_Stepper
```

**Profile values:**

| Key | Value | Notes |
|-----|-------|-------|
| `motor_type` | 2 | two-phase stepper |
| `n_pole_pairs` | 50 | |
| `motor_kt` | 0.22 N·m/A | derived from 0.55 Nm holding torque / 2.5 A holding current |
| `jmotor` | 8.2×10⁻⁶ kg·m² | |
| `abn_decoder_ppr` | 4000 | |
| `abn_direction` | `True` | encoder direction reversed |

**Implementation note:** builtin profile dicts are returned raw by `_resolve_profile` and never pass through `FocMotor._validate`, so `holding_current`/`holding_torque` cannot be stored directly — `motor_kt` is pre-computed here. The `foc_` config-file prefix is stripped by `ConfigWithDefaults._lookup`, so the dict key is `abn_direction` (not `foc_abn_direction`).