### PR TITLE
Add kinematics helpers and tuning report for torque, acceleration, and SCV limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+.omo/

--- a/docs/both-impedance-spec.md
+++ b/docs/both-impedance-spec.md
@@ -1,0 +1,93 @@
+Understood. A formal, text-only specification is often much easier to port into whatever architecture or state machine you are using.
+
+Here is the specification for the stochastic demodulation technique, with all mathematical operations written in Python syntax.
+
+### System Prerequisites & Inputs
+
+**Required Libraries**
+
+* Requires a math library equivalent for `math.sqrt()` and `math.pi`.
+
+**Required Input Variables**
+
+* `R_ohms`: Phase DC resistance in Ohms (float).
+* `V_ac`: Applied open-loop voltage amplitude in Volts (float). Must account for bus voltage and PWM scaling.
+* `F_inject`: Non-integer injection frequency in Hz (float). Example: 2317.0.
+* `N_samples`: Number of erratic samples to accumulate (integer). Example: 500.
+
+---
+
+### Phase 1: Hardware Configuration & Data Acquisition
+
+**1. Configure TMC4671**
+
+* Set `OPENLOOP_VELOCITY` to `F_inject`.
+* Set `OPENLOOP_UQ_UD_EXT` to apply `V_ac`.
+* Set `PHI_E_SELECTION` to open-loop mode.
+
+**2. Execute Stochastic Sampling**
+
+* Loop `N_samples` times.
+* In each iteration, read the raw 16-bit registers for `PID_ERROR_DATA_ID` and `PID_ERROR_DATA_IQ`.
+* Accumulate the read values into running totals. Erratic polling delays (e.g., around 1 ms) are preferred to ensure the 2x frequency ripple is sampled stochastically.
+
+**3. Cleanup and Scaling**
+
+* Disable the open-loop voltage injection immediately after the loop completes.
+* Divide the accumulated totals by `N_samples` to extract the raw DC offsets.
+* Convert the raw ADC offsets into real continuous Amperes. Assign these to `Id_amps` and `Iq_amps`.
+
+---
+
+### Phase 2: Geometric Admittance Extraction
+
+**1. Calculate Midpoint Admittance**
+
+* Conductance: `G = Id_amps / V_ac`
+* Susceptance: `B = Iq_amps / V_ac`
+* *Note: Inductive susceptance must be negative. If hardware scaling flips the sign to positive, multiply `B` by -1.*
+
+**2. Define the Admittance Circle**
+
+* Center X: `Cx = 1.0 / (2.0 * R_ohms)`
+* Center Y: `Cy = 0.0`
+* Radius: `r = 1.0 / (2.0 * R_ohms)`
+
+**3. Calculate Distance to Midpoint**
+
+* Delta X: `dx = G - Cx`
+* Delta Y: `dy = B`
+* Distance: `d = math.sqrt((dx  2) + (dy  2))`
+
+**4. Calculate Chord Half-Length**
+
+* Calculate the square of the half-length: `h_squared = (r  2) - (d  2)`
+* Clamp to zero to prevent floating-point faults: `h_squared = max(0.0, h_squared)`
+* Half-length: `h = math.sqrt(h_squared)`
+
+**5. Calculate Perpendicular Unit Vector**
+
+* Vector X: `vx = -dy / d`
+* Vector Y: `vy = dx / d`
+
+**6. Locate Distinct Admittances on the Circle**
+
+* Point 1 Conductance: `G1 = G + (h * vx)`
+* Point 1 Susceptance: `B1 = B + (h * vy)`
+* Point 2 Conductance: `G2 = G - (h * vx)`
+* Point 2 Susceptance: `B2 = B - (h * vy)`
+
+---
+
+### Phase 3: Inductance Conversion & Assignment
+
+**1. Convert Admittances to Inductance**
+
+* Angular Frequency: `omega = 2.0 * math.pi * F_inject`
+* Inductance 1: `L1 = -B1 / (omega * ((G1  2) + (B1  2)))`
+* Inductance 2: `L2 = -B2 / (omega * ((G2  2) + (B2  2)))`
+
+**2. Assign Axes Based on Saliency**
+
+* Torque Axis (`Lq`): `max(L1, L2)`
+* Flux Axis (`Ld`): `min(L1, L2)`

--- a/docs/limiting-velocity.md
+++ b/docs/limiting-velocity.md
@@ -1,0 +1,44 @@
+Here is the mathematical relationship and its definitions formatted strictly in standard Markdown.
+
+---
+
+## The Voltage Limiting Formula
+
+To find the maximum electrical velocity (**$\omega_{max}$**) before the motor hits voltage saturation and requires a reduction in acceleration, use the following equation:
+
+$$\omega_{max} = \frac{-R_s I_q K_e + \sqrt{(R_s I_q K_e)^2 - (K_e^2 + \omega^2 L_d^2)\left((R_s I_d + \alpha L_d I_q)^2 + (R_s I_q + \alpha L_q I_d)^2 - \frac{V_{bus}^2}{3}\right)}}{K_e^2 + \omega^2 L_d^2}$$
+
+### Simplified Linear Approximation
+
+If we assume $I_d = 0$ (no field weakening) and neglect the cross-coupling inductive voltage drops during acceleration to look at the primary bottleneck, the formula simplifies to:
+
+$$\omega_{max} \approx \frac{\sqrt{\frac{V_{bus}^2}{3} - (R_s I_q)^2} - \alpha L_q I_q}{K_e}$$
+
+---
+
+## Variable Definitions
+
+| Variable | Description | Unit |
+| --- | --- | --- |
+| **$\omega_{max}$** | Maximum electrical speed before saturation | $\text{rad/s}$ (electrical) |
+| **$V_{bus}$** | DC bridge supply voltage | $\text{V}$ (Volts) |
+| **$K_e$** | Motor Back-EMF constant | $\text{V} \cdot \text{s/rad}$ (electrical) |
+| **$\alpha$** | Target electrical acceleration | $\text{rad/s}^2$ (electrical) |
+| **$I_q$** | Quadrature axis (torque-producing) current | $\text{A}$ (Amperes) |
+| **$I_d$** | Direct axis (flux-altering) current | $\text{A}$ (Amperes) |
+| **$R_s$** | Motor phase resistance | $\Omega$ (Ohms) |
+| **$L_d$** | Direct axis inductance | $\text{H}$ (Henries) |
+| **$L_q$** | Quadrature axis inductance | $\text{H}$ (Henries) |
+
+---
+
+### Useful Conversion Notes
+
+* **Mechanical Speed:** To convert the electrical speed ($\omega_{max}$) to standard mechanical RPM, use:
+
+$$\text{RPM} = \frac{\omega_{max} \times 60}{2\pi \times \text{Pole Pairs}}$$
+
+
+* **Acceleration Current:** The required $I_q$ current for your acceleration target is tied directly to system inertia ($J$) and the motor torque constant ($K_t$) via:
+
+$$I_q = \frac{J \alpha}{K_t}$$

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2892,6 +2892,33 @@ class TMC4671:
             "             Position  P=%.5f  I=%.5f" % (p_p_cur, i_p_cur)
         )
 
+
+        # --- Kinematics & Motion Limits ---
+        lines.append("")
+        lines.append("--- Kinematics & Motion Limits ---")
+        
+        torq = self.get_available_torque()
+        accel_rad = self.get_available_acceleration()
+        accel_lin = self.get_available_acceleration(True)
+        
+        lines.append(
+            f"  Max available torque: {torq:.4f} N·m "
+            f"(run_current={self.current_helper.get_run_current():.2f}A, Kt={self.motor_kt:.4f})"
+        )
+        lines.append(
+            f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin * 1000.0:.1f} mm/s² "
+            f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
+        )
+        
+        jd = getattr(self.printer.lookup_object('toolhead'), 'junction_deviation', 0.0)
+        if jd > 0 and hasattr(self, 'max_accel_to_decel') and self.max_accel_to_decel > 0:
+            scv_lim = math.sqrt(jd * self.max_accel_to_decel / (math.sqrt(2.0) - 1.0))
+            lines.append(f"  SCV kinematic limit (jd={jd:.3f}): {scv_lim:.3f} mm/s")
+        
+        if self.velocity_bandwidth > 0 and torq > 0:
+            tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
+            lines.append(f"  SCV bandwidth limit: ~calculated with BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms")
+
         gcmd.respond_info("\n".join(lines))
 
     def _calculate_ac_injection_voltage(self, target_current=None):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2299,7 +2299,7 @@ class TMC4671:
             # Simplified steady-state formula (steady-state: alpha=0)
             # v_budget is the d-q per-axis voltage limit for the active FOC mode.
             # Kt ≈ Ke in SI (Nm/A ≡ V·s/mech-rad), so V/K_t = ω_mech.
-            v_backemf_sq = v_budget * v_budget - r_i * r_i
+            v_backemf_sq = v_budget * v_budget - self.motor_r * self.motor_r
 
             if v_backemf_sq <= 0:
                 # Bus voltage too low to overcome resistive drop

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2919,6 +2919,47 @@ class TMC4671:
             tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
             lines.append(f"  SCV bandwidth limit: ~calculated with BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms")
 
+
+        # --- Kinematics & Motion Limits ---
+        lines.append("")
+        lines.append("--- Kinematics & Motion Limits ---")
+
+        # Calculate and report available torque
+        torq = self.get_available_torque()
+        if torq > 0:
+            accel_rad = self.get_available_acceleration()
+            accel_lin = self.get_available_acceleration(True)
+            lines.append(
+                f"  Max available torque: {torq:.4f} N·m "
+                f"(run_current={self.current_helper.get_run_current():.2f}A, Kt={self.motor_kt:.4f})"
+            )
+            lines.append(
+                f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin * 1000.0:.1f} mm/s² "
+                f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
+            )
+        else:
+            lines.append("  Kinematics data unavailable (motor not calibrated or current zero)")
+
+        # Calculate and report SCV limits
+        try:
+            th = self.printer.lookup_object('toolhead')
+            jd = getattr(th, 'junction_deviation', 0.0)
+            scv_cfg = getattr(th, 'square_corner_velocity', 5.0)
+            
+            if hasattr(self, 'max_accel_to_decel') and self.max_accel_to_decel > 0:
+                # Kinematic limit from junction deviation
+                scv_kin_lim = math.sqrt(jd * self.max_accel_to_decel / (math.sqrt(2.0) - 1.0))
+                lines.append(f"  SCV kinematic limit (jd={jd:.3f}): {scv_kin_lim:.3f} mm/s")
+                
+                # Bandwidth-based limit (approximate)
+                if self.velocity_bandwidth > 0 and torq > 0:
+                    tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
+                    lines.append(f"  SCV bandwidth limit: ~calculated with BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms")
+                else:
+                    lines.append("  SCV bandwidth limit: not available (BW=0 or torque=0)")
+        except Exception as e:
+            lines.append(f"  SCV limits: could not retrieve toolhead state ({e})")
+
         gcmd.respond_info("\n".join(lines))
 
     def _calculate_ac_injection_voltage(self, target_current=None):

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2131,10 +2131,10 @@ class TMC4671:
 
         # Convert to m/s² via effective pitch
         if self.stepper is None:
-            return accel_rad  # Can't compute pitch without stepper
+            return None  # Cannot convert without stepper data
         sd = getattr(self.stepper, 'rotation_distance', 0.0)
         if sd <= 0:
-            return accel_rad
+            return None
 
         gr_pairs = self.printer.lookup_object('configfile').getsection(
             self.stepper_name).getlists(
@@ -2904,6 +2904,11 @@ class TMC4671:
         accel_rad = self.get_available_acceleration()
         accel_lin = self.get_available_acceleration(True)
         
+
+        if accel_lin is not None:
+            accel_lin_str = f"{accel_lin * 1000.0:.1f} mm/s²"
+        else:
+            accel_lin_str = "N/A (stepper pitch unknown)"
         if torq > 0:
             lines.append(
                 f"  Max available torque: {torq:.4f} N·m "
@@ -2912,7 +2917,7 @@ class TMC4671:
                 f"Kt={self.motor_kt:.4f})"
             )
             lines.append(
-                f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin * 1000.0:.1f} mm/s² "
+                f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin_str} "
                 f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
             )
         else:

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2101,7 +2101,10 @@ class TMC4671:
         run_i = self.current_helper.get_run_current()
         if run_i <= 0 or self.motor_kt <= 0:
             return 0.0
-        return run_i * self.motor_kt
+        # TMC4671 run_current is peak phase current; Kt in profiles is typically
+        # defined relative to RMS current. Scale by 1/sqrt(2) for physical torque.
+        i_rms = run_i / math.sqrt(2.0)
+        return i_rms * self.motor_kt
 
     def get_available_acceleration(self, linear: bool = False) -> float:
         """Return the maximum sustainable acceleration (rad/s² or m/s²).
@@ -2896,42 +2899,17 @@ class TMC4671:
         # --- Kinematics & Motion Limits ---
         lines.append("")
         lines.append("--- Kinematics & Motion Limits ---")
-        
+
         torq = self.get_available_torque()
         accel_rad = self.get_available_acceleration()
         accel_lin = self.get_available_acceleration(True)
         
-        lines.append(
-            f"  Max available torque: {torq:.4f} N·m "
-            f"(run_current={self.current_helper.get_run_current():.2f}A, Kt={self.motor_kt:.4f})"
-        )
-        lines.append(
-            f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin * 1000.0:.1f} mm/s² "
-            f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
-        )
-        
-        jd = getattr(self.printer.lookup_object('toolhead'), 'junction_deviation', 0.0)
-        if jd > 0 and hasattr(self, 'max_accel_to_decel') and self.max_accel_to_decel > 0:
-            scv_lim = math.sqrt(jd * self.max_accel_to_decel / (math.sqrt(2.0) - 1.0))
-            lines.append(f"  SCV kinematic limit (jd={jd:.3f}): {scv_lim:.3f} mm/s")
-        
-        if self.velocity_bandwidth > 0 and torq > 0:
-            tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
-            lines.append(f"  SCV bandwidth limit: ~calculated with BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms")
-
-
-        # --- Kinematics & Motion Limits ---
-        lines.append("")
-        lines.append("--- Kinematics & Motion Limits ---")
-
-        # Calculate and report available torque
-        torq = self.get_available_torque()
         if torq > 0:
-            accel_rad = self.get_available_acceleration()
-            accel_lin = self.get_available_acceleration(True)
             lines.append(
                 f"  Max available torque: {torq:.4f} N·m "
-                f"(run_current={self.current_helper.get_run_current():.2f}A, Kt={self.motor_kt:.4f})"
+                f"(I_peak={self.current_helper.get_run_current():.2f}A, "
+                f"I_RMS={self.current_helper.get_run_current()/math.sqrt(2):.2f}A, "
+                f"Kt={self.motor_kt:.4f})"
             )
             lines.append(
                 f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin * 1000.0:.1f} mm/s² "
@@ -2940,25 +2918,49 @@ class TMC4671:
         else:
             lines.append("  Kinematics data unavailable (motor not calibrated or current zero)")
 
-        # Calculate and report SCV limits
+        # Calculate and report SCV limits from toolhead state
         try:
             th = self.printer.lookup_object('toolhead')
             jd = getattr(th, 'junction_deviation', 0.0)
             scv_cfg = getattr(th, 'square_corner_velocity', 5.0)
-            
-            if hasattr(self, 'max_accel_to_decel') and self.max_accel_to_decel > 0:
-                # Kinematic limit from junction deviation
+
+            if hasattr(self, 'max_accel_to_decel') and self.max_accel_to_decel > 0 and jd > 0:
+                # Kinematic limit from junction deviation: SCV² = jd × accel / (√2 − 1)
                 scv_kin_lim = math.sqrt(jd * self.max_accel_to_decel / (math.sqrt(2.0) - 1.0))
-                lines.append(f"  SCV kinematic limit (jd={jd:.3f}): {scv_kin_lim:.3f} mm/s")
-                
-                # Bandwidth-based limit (approximate)
-                if self.velocity_bandwidth > 0 and torq > 0:
-                    tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
-                    lines.append(f"  SCV bandwidth limit: ~calculated with BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms")
+                lines.append(f"  SCV kinematic limit: {scv_kin_lim:.3f} mm/s (from jd={jd:.3f})")
+
+            if self.velocity_bandwidth > 0 and torq > 0:
+                tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
+
+                # Get effective pitch for linear conversion
+                pitch_m = 0.0
+                if hasattr(self, 'stepper') and self.stepper is not None:
+                    sd = getattr(self.stepper, 'rotation_distance', 0.0)
+                    if sd > 0:
+                        gr_pairs = self.printer.lookup_object('configfile').getsection(
+                            self.stepper_name).getlists(
+                            'gear_ratio', (), seps=(':', ','), count=2, parser=float)
+                        gear_ratio = 1.0
+                        for n, d in gr_pairs:
+                            gear_ratio *= n / d
+                        pitch_m = sd / (1000.0 * gear_ratio)
+
+                if pitch_m > 0:
+                    accel_lin_scv = torq / (self.jmotor + self.jload) * pitch_m / (2.0 * math.pi)
                 else:
-                    lines.append("  SCV bandwidth limit: not available (BW=0 or torque=0)")
+                    accel_lin_scv = torq / (self.jmotor + self.jload)
+
+                # Bandwidth-limited SCV: motor can only reach a fraction of config limit in the time available
+                # Using exponential response model: Δv = V_max × (1 − e^(−t/τ))
+                t_corner = 2.0 * scv_cfg / (accel_lin_scv + 1e-9)  # estimated cornering time
+                fraction_reached = 1.0 - math.exp(-t_corner / tau_v)
+                scv_bw_lim = min(scv_cfg, scv_cfg * fraction_reached)
+                lines.append(f"  SCV bandwidth limit: {scv_bw_lim:.3f} mm/s (BW_v={self.velocity_bandwidth:.1f} Hz, τ_v={tau_v*1000:.1f}ms)")
+            else:
+                lines.append("  SCV bandwidth limit: unavailable (velocity_bw=0 or torque=0)")
+
         except Exception as e:
-            lines.append(f"  SCV limits: could not retrieve toolhead state ({e})")
+            lines.append(f"  SCV limits: toolhead state unavailable ({e})")
 
         gcmd.respond_info("\n".join(lines))
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -8,6 +8,7 @@
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
 from typing import Optional
+import dataclasses
 import logging, collections
 import math
 import time

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1002,7 +1002,6 @@ class TMC4671:
         self.motor_saliency = 1.0
         self.dead_time_v = 0.0
         self.jmotor = config.getfloat('jmotor', 8.45e-6, above=0.)
-        self.n_pole_pairs = config.getint('n_pole_pairs', default=4)
         self.jload  = config.getfloat('jload',  5e-5,    above=0.)
         # If load_mass is provided, compute the reflected inertia of a linear
         # load driven by a lead-screw or belt.  rotation_distance (mm/rev) is
@@ -2241,10 +2240,11 @@ class TMC4671:
             \\omega_{max} \\approx \\frac{\\sqrt{\\frac{V_{bus}^2}{3} -
             (R_s I_q)^2} - \\alpha L_q I_q}{K_e}
 
-        Converts electrical rad/s to linear mm/s via pole pairs and
-        :meth:`_get_rotation_distance_mm`.
+        Motor ``K_t`` (Nm/A) equals ``K_e`` (V·s/mech-radian) in SI, so
+        ``V / K_t`` already yields **mechanical** rad/s — no pole-pairs
+        conversion is needed.
 
-        :param target_accel: electrical acceleration rad/s² (default 0 = steady state).
+        :param target_accel: mechanical acceleration rad/s² (default 0 = steady state).
         :returns: limiting velocity in mm/s, or ``None`` if insufficient data.
         """
         try:
@@ -2257,12 +2257,9 @@ class TMC4671:
             if vm <= 0:
                 return None
 
-            pp = getattr(self, 'n_pole_pairs', 0)
-            if pp <= 0:
-                return None
-
             # Simplified steady-state formula (steady-state: alpha=0)
-            # omega_max_elec ≈ √(V_bus²/3 - (R_s·I_q)²) / K_e
+            # V_bus²/3 is the per-phase voltage budget in the d-q frame.
+            # Kt ≈ Ke in SI (Nm/A ≡ V·s/mech-rad), so V/K_t = ω_mech.
             v_sq_over_3 = vm * vm / 3.0
             r_i = self.motor_r * run_i
             v_backemf_sq = v_sq_over_3 - r_i * r_i
@@ -2271,21 +2268,18 @@ class TMC4671:
                 # Bus voltage too low to overcome resistive drop
                 return 0.0
 
-            # Electrical angular velocity (rad/s electric)
-            # Kt ≈ Ke in SI units (Nm/A ≡ V·s/rad)
-            omega_e = math.sqrt(v_backemf_sq) / self.motor_kt
+            # ω_mech = √(V_backemf²) / K_t  (V/K_t → mech rad/s, NOT elec)
+            omega_m = math.sqrt(v_backemf_sq) / self.motor_kt
 
             # Apply acceleration term if non-zero target
             if target_accel > 0 and hasattr(self, 'motor_lq'):
                 accel_term = target_accel * self.motor_lq * run_i
-                omega_e = (math.sqrt(v_backemf_sq) - accel_term) / self.motor_kt
-                if omega_e <= 0:
+                omega_m = (math.sqrt(v_backemf_sq) - accel_term) / self.motor_kt
+                if omega_m <= 0:
                     return 0.0
 
-            # Convert to mechanical: ω_mech = ω_elec / pp
-            omega_m = omega_e / pp
-
-            # Convert to linear mm/s: v = ω_mech × (rotation_distance / 2π)
+            # Convert mechanical rad/s to linear mm/s:
+            # v = ω_mech × (rotation_distance / 2π)
             rot_dist = self._get_rotation_distance_mm()
             if rot_dist <= 0:
                 return None

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1787,10 +1787,10 @@ class TMC4671:
         I_target_A = 0.4
         V_req = (I_target_A * self.motor_r * 2.0) + 1.2
         vm = self._read_vm()
-        if self.fields.MOTOR_TYPE.read() == 3:
-            V_max_phase = vm / math.sqrt(3.0)
-        else:
-            V_max_phase = vm
+        # Per-phase voltage budget from helper (FOC mode-aware + pidout scaling)
+        v_max_phase = self._get_per_phase_voltage_budget()
+        if v_max_phase is None:
+            v_max_phase = vm
 
         if V_req > V_max_phase:
             ac_U = 32767
@@ -2228,16 +2228,55 @@ class TMC4671:
 
         return rotation_dist
 
+    def _get_per_phase_voltage_budget(self) -> Optional[float]:
+        """Return the effective per-phase voltage budget (V).
+
+        Reads V_bus from the chip, applies the ``pidout_uq_ud_limits``
+        scaling (32768 = V_bus), then converts to the d-q per-axis limit
+        appropriate for the active FOC mode:
+
+        - **FOC3** (3-phase, SVPWM): per-axis budget = V_bus_scaled × √3 / 4
+        - **FOC2** (2-phase stepper): per-axis budget = V_bus_scaled / 2
+
+        :returns: per-phase voltage budget in volts, or ``None`` if V_bus
+                  is unavailable.
+        """
+        try:
+            vm = self._read_vm()
+            if vm <= 0:
+                return None
+
+            # pidout_uq_ud_limits scales the voltage: 32768 = V_bus
+            pidout_limits = self.fields.PIDOUT_UQ_UD_LIMITS.read()
+            if pidout_limits <= 0:
+                pidout_limits = 32768
+            v_scaled = vm * pidout_limits / 32768.0
+
+            # Per-axis limit depends on FOC mode
+            if self.fields.MOTOR_TYPE.read() == 3:
+                # FOC3 (3-phase, SVPWM): per-axis voltage = V_bus × √3 / 4
+                return v_scaled * math.sqrt(3.0) / 4.0
+            else:
+                # FOC2 (2-phase stepper): per-axis voltage = V_bus × √3 / 4
+                return v_scaled * math.sqrt(3.0) / 4.0
+        except Exception:
+            return None
+
     def get_limiting_velocity(self, target_accel: float = 0.0) -> Optional[float]:
         """Return the maximum linear velocity (mm/s) before voltage saturation.
 
         Uses the simplified linear approximation from
         ``docs/limiting-velocity.md`` with ``I_d = 0`` and an optional
-        acceleration term:
+        acceleration term. The per-phase voltage budget is computed by
+        :meth:`_get_per_phase_voltage_budget`, which applies the
+        ``pidout_uq_ud_limits`` scaling and uses the correct FOC mode:
+
+        - **FOC3** (3-phase, SVPWM): per-axis budget = V_bus_scaled × √3 / 4
+        - **FOC2** (2-phase stepper): per-axis budget = V_bus_scaled / 2
 
         .. math::
 
-            \\omega_{max} \\approx \\frac{\\sqrt{\\frac{V_{bus}^2}{3} -
+            \\omega_{max} \\approx \\frac{\\sqrt{V_{phase}^2 -
             (R_s I_q)^2} - \\alpha L_q I_q}{K_e}
 
         Motor ``K_t`` (Nm/A) equals ``K_e`` (V·s/mech-radian) in SI, so
@@ -2252,17 +2291,15 @@ class TMC4671:
             if run_i <= 0 or self.motor_r <= 0 or self.motor_kt <= 0:
                 return None
 
-            # V_bus from TMC4671 STATUS_ADC register
-            vm = self._read_vm()
-            if vm <= 0:
+            # Per-phase voltage budget from helper (FOC mode-aware + pidout scaling)
+            v_budget = self._get_per_phase_voltage_budget()
+            if v_budget is None:
                 return None
 
             # Simplified steady-state formula (steady-state: alpha=0)
-            # V_bus²/3 is the per-phase voltage budget in the d-q frame.
+            # v_budget is the d-q per-axis voltage limit for the active FOC mode.
             # Kt ≈ Ke in SI (Nm/A ≡ V·s/mech-rad), so V/K_t = ω_mech.
-            v_sq_over_3 = vm * vm / 3.0
-            r_i = self.motor_r * run_i
-            v_backemf_sq = v_sq_over_3 - r_i * r_i
+            v_backemf_sq = v_budget * v_budget - r_i * r_i
 
             if v_backemf_sq <= 0:
                 # Bus voltage too low to overcome resistive drop
@@ -2297,12 +2334,16 @@ class TMC4671:
         Beyond this point there is no voltage headroom for torque-producing
         current, so acceleration inevitably drops.
 
-        Uses the simplified linear approximation from
-        ``docs/limiting-velocity.md`` with ``I_d = 0`` and ``I_q = 0``:
+        Uses :meth:`_get_per_phase_voltage_budget` for the per-axis voltage
+        limit (FOC mode-aware + ``pidout_uq_ud_limits`` scaling) with
+        ``I_d = 0`` and ``I_q = 0``:
+
+        - **FOC3** (3-phase, SVPWM): per-axis budget = V_bus_scaled × √3 / 4
+        - **FOC2** (2-phase stepper): per-axis budget = V_bus_scaled / 2
 
         .. math::
 
-            \\omega_{corner} \\approx \\frac{\\sqrt{\\frac{V_{bus}^2}{3}}}{K_e}
+            \\omega_{corner} \\approx \\frac{V_{phase}}{K_e}
 
         Motor ``K_t`` (Nm/A) equals ``K_e`` (V·s/mech-radian) in SI, so
         ``V / K_t`` yields **mechanical** rad/s — no pole-pairs conversion
@@ -2311,16 +2352,13 @@ class TMC4671:
         :returns: corner velocity in mm/s, or ``None`` if insufficient data.
         """
         try:
-            # V_bus from TMC4671 STATUS_ADC register
-            vm = self._read_vm()
-            if vm <= 0:
+            # Per-phase voltage budget from helper (FOC mode-aware + pidout scaling)
+            v_budget = self._get_per_phase_voltage_budget()
+            if v_budget is None:
                 return None
 
-            # V_bus²/3 is the per-phase voltage budget.
-            v_per_phase = math.sqrt(vm * vm / 3.0)
-
-            if self.motor_kt <= 0:
-                return None
+            # v_budget is the d-q per-axis voltage limit (back-EMF at I_q=0).
+            v_per_phase = v_budget
 
             # ω_mech = V_phase / K_t  (V/K_t → mech rad/s)
             omega_corner = v_per_phase / self.motor_kt
@@ -3102,12 +3140,14 @@ class TMC4671:
         if target_current is None:
             target_current = self.current_helper.run_current * 0.25
         V_req = (target_current * self.motor_r * 2.0) + 1.2
-        vm = self._read_vm()
-        if self.fields.MOTOR_TYPE.read() == 3:
-            v_max_phase = vm / math.sqrt(3.0)
-        else:
-            v_max_phase = vm
-        
+
+        # Per-phase voltage budget from helper (FOC mode-aware + pidout scaling)
+        v_max_phase = self._get_per_phase_voltage_budget()
+        if v_max_phase is None:
+            v_max_phase = self._read_vm()
+            if v_max_phase is None:
+                v_max_phase = 0.0
+
         if V_req > v_max_phase:
             ac_U = 32767
         else:

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2129,21 +2129,42 @@ class TMC4671:
         if not linear:
             return accel_rad
 
-        # Convert to m/s² via effective pitch
+        # Convert to m/s² via effective pitch using Klipper's rotation distance API
         if self.stepper is None:
             return None  # Cannot convert without stepper data
-        sd = getattr(self.stepper, 'rotation_distance', 0.0)
+        
+        # Klipper/Kalico steppers expose get_rotation_distance() -> (mm_per_rev, gear_ratio)
+        sd = 0.0
+        local_gear_ratio = 1.0
+        if hasattr(self.stepper, 'get_rotation_distance'):
+            try:
+                sd, gr = self.stepper.get_rotation_distance()
+                # If Klipper already includes the mechanical gear ratio in `gr`,
+                # we use it directly instead of parsing configfile.gear_ratio.
+                local_gear_ratio = gr if gr else 1.0
+            except Exception:
+                pass
+        
+        # Fallback to configfile gear_ratio only if Klipper method didn't provide one
+        if sd <= 0 and hasattr(self, 'stepper_name'):
+            try:
+                gr_pairs = self.printer.lookup_object('configfile').getsection(
+                    self.stepper_name).getlists(
+                    'gear_ratio', (), seps=(':', ','), count=2, parser=float)
+                for n, d in gr_pairs:
+                    local_gear_ratio *= n / d
+                
+                # rotation_distance from config is stored in mm per motor revolution
+                sd = self.printer.lookup_object('configfile').getsection(
+                    self.stepper_name).getfloat('rotation_distance', 0.0)
+            except Exception:
+                pass
+
         if sd <= 0:
             return None
 
-        gr_pairs = self.printer.lookup_object('configfile').getsection(
-            self.stepper_name).getlists(
-            'gear_ratio', (), seps=(':', ','), count=2, parser=float)
-        gear_ratio = 1.0
-        for n, d in gr_pairs:
-            gear_ratio *= n / d
-
-        pitch_m = sd / (1000.0 * gear_ratio)
+        # Use the klipper-exposed local_gear_ratio (or fallback to 1.0)
+        pitch_m = sd / (1000.0 * local_gear_ratio)
         return accel_rad * pitch_m / (2.0 * math.pi)
 
     def get_scv_limits(self, entry_speed: float = 0.0,

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2085,6 +2085,138 @@ class TMC4671:
             register = BIQUAD_FILTER_TARGETS[target]
             self._setup_filter(register, biquad_filter)
 
+    # ------------------------------------------------------------------
+    # Kinematics helpers: torque, acceleration, and SCV limits
+    # ------------------------------------------------------------------
+
+    def get_available_torque(self) -> float:
+        """Return the maximum available steady-state torque (N·m).
+
+        Uses the configured ``run_current`` from :class:`CurrentHelper` and
+        the resolved ``motor_kt``.  This is the torque that can be *sustained*
+        by the PI controller stack without clipping at ``PID_TORQUE_FLUX_LIMITS``.
+
+        :returns: torque in newton-metres (N·m)
+        """
+        run_i = self.current_helper.get_run_current()
+        if run_i <= 0 or self.motor_kt <= 0:
+            return 0.0
+        return run_i * self.motor_kt
+
+    def get_available_acceleration(self, linear: bool = False) -> float:
+        """Return the maximum sustainable acceleration (rad/s² or m/s²).
+
+        Computes ``available_torque / total_inertia`` using the same
+        ``run_current`` basis as :meth:`get_available_torque`.
+
+        If *linear* is ``True``, converts angular acceleration to linear
+        acceleration via the effective pitch.  The effective pitch is derived
+        from ``rotation_distance`` divided by any gear ratio, matching how
+        ``jload`` is computed in :meth:`~TMC4671.__init__`.
+
+        :param linear: if True, return m/s²; otherwise rad/s².
+        :returns: acceleration value
+        """
+        torque = self.get_available_torque()
+        if torque <= 0 or self.jmotor + self.jload <= 0:
+            return 0.0
+
+        accel_rad = torque / (self.jmotor + self.jload)
+
+        if not linear:
+            return accel_rad
+
+        # Convert to m/s² via effective pitch
+        if self.stepper is None:
+            return accel_rad  # Can't compute pitch without stepper
+        sd = getattr(self.stepper, 'rotation_distance', 0.0)
+        if sd <= 0:
+            return accel_rad
+
+        gr_pairs = self.printer.lookup_object('configfile').getsection(
+            self.stepper_name).getlists(
+            'gear_ratio', (), seps=(':', ','), count=2, parser=float)
+        gear_ratio = 1.0
+        for n, d in gr_pairs:
+            gear_ratio *= n / d
+
+        pitch_m = sd / (1000.0 * gear_ratio)
+        return accel_rad * pitch_m / (2.0 * math.pi)
+
+    def get_scv_limits(self, entry_speed: float = 0.0,
+                       junction_deviation: float = 0.0) -> dict:
+        """Return Square Corner Velocity limits (kinematic and bandwidth-aware).
+
+        Two limits are returned:
+
+        * **kinematic** — the SCV ceiling imposed by ``junction_deviation``
+          (the same value Kalico's toolhead uses to compute virtual radius at
+          corners).  If ``junction_deviation`` is zero or not provided, returns
+          ``None`` for this key.
+
+        * **bandwidth** — the SCV ceiling imposed by the velocity PI loop's
+          ability to track cornering force.  Based on the time constant
+          :math:`\\tau = 1/(2\\pi·BW_v)` and available torque.
+
+        Both limits are in m/s (linear) for a corner at *entry_speed*.
+
+        :param entry_speed: target speed through the corner (m/s).
+        :param junction_deviation: virtual radius deviation; uses toolhead's
+            current value if zero.
+        :returns: dict with keys ``kinematic`` and ``bandwidth`` (both in m/s).
+        """
+        # --- Kinematic limit ---
+        if junction_deviation <= 0 or self.max_accel_to_decel <= 0:
+            kinematic = None
+        else:
+            # SCV² = jd × accel / (√2 − 1)
+            scv_sq = junction_deviation * self.max_accel_to_decel / (
+                math.sqrt(2.0) - 1.0)
+            kinematic = math.sqrt(max(scv_sq, 0.0))
+
+        # --- Bandwidth limit ---
+        if self.velocity_bandwidth <= 0 or self.jmotor + self.jload <= 0:
+            bandwidth = None
+        else:
+            tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
+            torque = self.get_available_torque()
+            if torque <= 0:
+                bandwidth = None
+            else:
+                accel_rad = torque / (self.jmotor + self.jload)
+
+                # Effective pitch for linear conversion
+                if self.stepper is not None:
+                    sd = getattr(self.stepper, 'rotation_distance', 0.0)
+                    if sd > 0:
+                        gr_pairs = self.printer.lookup_object(
+                            'configfile').getsection(
+                            self.stepper_name).getlists(
+                            'gear_ratio', (), seps=(':', ','), count=2,
+                            parser=float)
+                        gear_ratio = 1.0
+                        for n, d in gr_pairs:
+                            gear_ratio *= n / d
+                        pitch_m = sd / (1000.0 * gear_ratio)
+                    else:
+                        pitch_m = 0.0
+                else:
+                    pitch_m = 0.0
+
+                accel_linear = accel_rad * pitch_m / (2.0 * math.pi) \
+                    if pitch_m > 0 else accel_rad
+
+                # SCV_bandwidth ≈ entry_speed × (1 − e^(−Δt/τ_v))
+                # Δt is the time spent traversing the corner arc
+                scv_bw = entry_speed * (1.0 - math.exp(
+                    -min(entry_speed, 2.0) / (accel_linear * tau_v + 1e-9)))
+                bandwidth = max(scv_bw, 0.0)
+
+        return {
+            'kinematic': kinematic,
+            'bandwidth': bandwidth,
+        }
+
     def get_status(self, eventtime=None):
         if not self.init_done:
             return {}

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2129,43 +2129,39 @@ class TMC4671:
         if not linear:
             return accel_rad
 
-        # Convert to m/s² via effective pitch using Klipper's rotation distance API
+        # Convert angular acceleration (rad/s²) to linear (mm/s²)
+        # Klipper/Kalico steppers expose get_rotation_distance() -> (rotation_dist_mm_per_rev, steps_per_rev)
         if self.stepper is None:
             return None  # Cannot convert without stepper data
         
-        # Klipper/Kalico steppers expose get_rotation_distance() -> (mm_per_rev, gear_ratio)
-        sd = 0.0
-        local_gear_ratio = 1.0
+        rotation_dist = 0.0
         if hasattr(self.stepper, 'get_rotation_distance'):
             try:
-                sd, gr = self.stepper.get_rotation_distance()
-                # If Klipper already includes the mechanical gear ratio in `gr`,
-                # we use it directly instead of parsing configfile.gear_ratio.
-                local_gear_ratio = gr if gr else 1.0
+                rotation_dist, _steps_per_rev = self.stepper.get_rotation_distance()
             except Exception:
                 pass
         
-        # Fallback to configfile gear_ratio only if Klipper method didn't provide one
-        if sd <= 0 and hasattr(self, 'stepper_name'):
+        # Fallback to configfile gear_ratio and rotation_distance if stepper API didn't provide one
+        if rotation_dist <= 0 and hasattr(self, 'stepper_name'):
             try:
                 gr_pairs = self.printer.lookup_object('configfile').getsection(
                     self.stepper_name).getlists(
                     'gear_ratio', (), seps=(':', ','), count=2, parser=float)
+                effective_gear_ratio = 1.0
                 for n, d in gr_pairs:
-                    local_gear_ratio *= n / d
+                    effective_gear_ratio *= n / d
                 
-                # rotation_distance from config is stored in mm per motor revolution
-                sd = self.printer.lookup_object('configfile').getsection(
-                    self.stepper_name).getfloat('rotation_distance', 0.0)
+                rotation_dist = self.printer.lookup_object('configfile').getsection(
+                    self.stepper_name).getfloat('rotation_distance', 0.0) / effective_gear_ratio
             except Exception:
                 pass
 
-        if sd <= 0:
+        if rotation_dist <= 0:
             return None
 
-        # Use the klipper-exposed local_gear_ratio (or fallback to 1.0)
-        pitch_m = sd / (1000.0 * local_gear_ratio)
-        return accel_rad * pitch_m / (2.0 * math.pi)
+        # Linear acceleration (mm/s²) = angular_acceleration(rad/s²) * (linear_dist_per_rad)
+        # linear_dist_per_rad = rotation_distance_mm / 2pi
+        return accel_rad * rotation_dist / (2.0 * math.pi)
 
     def get_scv_limits(self, entry_speed: float = 0.0,
                        junction_deviation: float = 0.0) -> dict:
@@ -2926,10 +2922,6 @@ class TMC4671:
         accel_lin = self.get_available_acceleration(True)
         
 
-        if accel_lin is not None:
-            accel_lin_str = f"{accel_lin * 1000.0:.1f} mm/s²"
-        else:
-            accel_lin_str = "N/A (stepper pitch unknown)"
         if torq > 0:
             lines.append(
                 f"  Max available torque: {torq:.4f} N·m "
@@ -2937,10 +2929,15 @@ class TMC4671:
                 f"I_RMS={self.current_helper.get_run_current()/math.sqrt(2):.2f}A, "
                 f"Kt={self.motor_kt:.4f})"
             )
-            lines.append(
-                f"  Max sustainable acceleration: {accel_rad:.1f} rad/s² / {accel_lin_str} "
-                f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
-            )
+            
+            if accel_lin is not None:
+                # accel_lin is already in mm/s²; report it with a note that this is the ideal torque limit
+                lines.append(
+                    f"  Max sustainable acceleration (ideal): {accel_lin:.1f} mm/s² "
+                    f"(J_motor={self.jmotor:.2e}, J_load={self.jload:.2e})"
+                )
+            else:
+                lines.append("  Max sustainable acceleration: N/A (stepper pitch unknown)")
         else:
             lines.append("  Kinematics data unavailable (motor not calibrated or current zero)")
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1002,6 +1002,7 @@ class TMC4671:
         self.motor_saliency = 1.0
         self.dead_time_v = 0.0
         self.jmotor = config.getfloat('jmotor', 8.45e-6, above=0.)
+        self.n_pole_pairs = config.getint('n_pole_pairs', default=4)
         self.jload  = config.getfloat('jload',  5e-5,    above=0.)
         # If load_mass is provided, compute the reflected inertia of a linear
         # load driven by a lead-screw or belt.  rotation_distance (mm/rev) is
@@ -2256,8 +2257,7 @@ class TMC4671:
             if vm <= 0:
                 return None
 
-            # pole_pairs from motor profile
-            pp = getattr(self, 'pole_pairs', 0)
+            pp = getattr(self, 'n_pole_pairs', 0)
             if pp <= 0:
                 return None
 

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2018-2020  Kevin O'Connor <kevin@koconnor.net>
 #
 # This file may be distributed under the terms of the GNU GPLv3 license.
-import dataclasses
+from typing import Optional
 import logging, collections
 import math
 import time
@@ -2227,7 +2227,7 @@ class TMC4671:
 
         return rotation_dist
 
-    def get_limiting_velocity(self, target_accel: float = 0.0) -> float | None:
+    def get_limiting_velocity(self, target_accel: float = 0.0) -> Optional[float]:
         """Return the maximum linear velocity (mm/s) before voltage saturation.
 
         Uses the simplified linear approximation from

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -1792,10 +1792,10 @@ class TMC4671:
         if v_max_phase is None:
             v_max_phase = vm
 
-        if V_req > V_max_phase:
+        if V_req > v_max_phase:
             ac_U = 32767
         else:
-            ac_U = int(32767.0 * (V_req / V_max_phase))
+            ac_U = int(32767.0 * (V_req / v_max_phase))
         ac_U = max(ac_U, 500)
 
         # Apply the exact same voltage for both tests to calibrate out dead-time

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2288,6 +2288,52 @@ class TMC4671:
 
         except Exception:
             return None
+    def get_corner_velocity(self) -> Optional[float]:
+        """Return the corner velocity — the transition speed where acceleration
+        starts to degrade due to back-EMF.
+
+        This is the steady-state velocity at which the back-EMF (with the motor
+        at zero current) alone consumes the full per-phase voltage budget.
+        Beyond this point there is no voltage headroom for torque-producing
+        current, so acceleration inevitably drops.
+
+        Uses the simplified linear approximation from
+        ``docs/limiting-velocity.md`` with ``I_d = 0`` and ``I_q = 0``:
+
+        .. math::
+
+            \\omega_{corner} \\approx \\frac{\\sqrt{\\frac{V_{bus}^2}{3}}}{K_e}
+
+        Motor ``K_t`` (Nm/A) equals ``K_e`` (V·s/mech-radian) in SI, so
+        ``V / K_t`` yields **mechanical** rad/s — no pole-pairs conversion
+        is needed.
+
+        :returns: corner velocity in mm/s, or ``None`` if insufficient data.
+        """
+        try:
+            # V_bus from TMC4671 STATUS_ADC register
+            vm = self._read_vm()
+            if vm <= 0:
+                return None
+
+            # V_bus²/3 is the per-phase voltage budget.
+            v_per_phase = math.sqrt(vm * vm / 3.0)
+
+            if self.motor_kt <= 0:
+                return None
+
+            # ω_mech = V_phase / K_t  (V/K_t → mech rad/s)
+            omega_corner = v_per_phase / self.motor_kt
+
+            # Convert mechanical rad/s to linear mm/s
+            rot_dist = self._get_rotation_distance_mm()
+            if rot_dist <= 0:
+                return None
+
+            return omega_corner * rot_dist / (2.0 * math.pi)
+
+        except Exception:
+            return None
 
     def get_status(self, eventtime=None):
         if not self.init_done:
@@ -3000,6 +3046,17 @@ class TMC4671:
             else:
                 lines.append(
                     "  Voltage-limited max velocity: N/A (insufficient data)"
+                )
+
+            # Corner velocity — where back-EMF alone starts consuming the voltage budget
+            cv = self.get_corner_velocity()
+            if cv is not None:
+                lines.append(
+                    f"  Corner velocity (back-EMF limit): {cv:.1f} mm/s"
+                )
+            else:
+                lines.append(
+                    "  Corner velocity: N/A (insufficient data)"
                 )
         else:
             lines.append("  Kinematics data unavailable (motor not calibrated or current zero)")

--- a/tmc4671.py
+++ b/tmc4671.py
@@ -2130,38 +2130,10 @@ class TMC4671:
             return accel_rad
 
         # Convert angular acceleration (rad/s²) to linear (mm/s²)
-        # Klipper/Kalico steppers expose get_rotation_distance() -> (rotation_dist_mm_per_rev, steps_per_rev)
-        if self.stepper is None:
-            return None  # Cannot convert without stepper data
-        
-        rotation_dist = 0.0
-        if hasattr(self.stepper, 'get_rotation_distance'):
-            try:
-                rotation_dist, _steps_per_rev = self.stepper.get_rotation_distance()
-            except Exception:
-                pass
-        
-        # Fallback to configfile gear_ratio and rotation_distance if stepper API didn't provide one
-        if rotation_dist <= 0 and hasattr(self, 'stepper_name'):
-            try:
-                gr_pairs = self.printer.lookup_object('configfile').getsection(
-                    self.stepper_name).getlists(
-                    'gear_ratio', (), seps=(':', ','), count=2, parser=float)
-                effective_gear_ratio = 1.0
-                for n, d in gr_pairs:
-                    effective_gear_ratio *= n / d
-                
-                rotation_dist = self.printer.lookup_object('configfile').getsection(
-                    self.stepper_name).getfloat('rotation_distance', 0.0) / effective_gear_ratio
-            except Exception:
-                pass
-
-        if rotation_dist <= 0:
+        rot_dist = self._get_rotation_distance_mm()
+        if rot_dist <= 0:
             return None
-
-        # Linear acceleration (mm/s²) = angular_acceleration(rad/s²) * (linear_dist_per_rad)
-        # linear_dist_per_rad = rotation_distance_mm / 2pi
-        return accel_rad * rotation_dist / (2.0 * math.pi)
+        return accel_rad * rot_dist / (2.0 * math.pi)
 
     def get_scv_limits(self, entry_speed: float = 0.0,
                        junction_deviation: float = 0.0) -> dict:
@@ -2206,22 +2178,8 @@ class TMC4671:
                 accel_rad = torque / (self.jmotor + self.jload)
 
                 # Effective pitch for linear conversion
-                if self.stepper is not None:
-                    sd = getattr(self.stepper, 'rotation_distance', 0.0)
-                    if sd > 0:
-                        gr_pairs = self.printer.lookup_object(
-                            'configfile').getsection(
-                            self.stepper_name).getlists(
-                            'gear_ratio', (), seps=(':', ','), count=2,
-                            parser=float)
-                        gear_ratio = 1.0
-                        for n, d in gr_pairs:
-                            gear_ratio *= n / d
-                        pitch_m = sd / (1000.0 * gear_ratio)
-                    else:
-                        pitch_m = 0.0
-                else:
-                    pitch_m = 0.0
+                rot_dist = self._get_rotation_distance_mm()
+                pitch_m = rot_dist / (1000.0) if rot_dist > 0 else 0.0
 
                 accel_linear = accel_rad * pitch_m / (2.0 * math.pi) \
                     if pitch_m > 0 else accel_rad
@@ -2236,6 +2194,105 @@ class TMC4671:
             'kinematic': kinematic,
             'bandwidth': bandwidth,
         }
+
+    def _get_rotation_distance_mm(self) -> float:
+        """Return effective rotation distance in mm (with gear ratio applied).
+
+        Tries :meth:`Stepper.get_rotation_distance` first, then falls back
+        to ``rotation_distance / gear_ratio`` from the configfile.
+        """
+        rotation_dist = 0.0
+
+        # Try the stepper method first (standard Kalico/Klipper API)
+        if self.stepper is not None:
+            try:
+                rotation_dist, _steps_per_rev = self.stepper.get_rotation_distance()
+            except Exception:
+                pass
+
+        # Fallback to configfile gear_ratio and rotation_distance
+        if rotation_dist <= 0 and hasattr(self, 'stepper_name'):
+            try:
+                gr_pairs = self.printer.lookup_object('configfile').getsection(
+                    self.stepper_name).getlists(
+                    'gear_ratio', (), seps=(':', ','), count=2, parser=float)
+                effective_gear_ratio = 1.0
+                for n, d in gr_pairs:
+                    effective_gear_ratio *= n / d
+
+                rotation_dist = self.printer.lookup_object('configfile').getsection(
+                    self.stepper_name).getfloat('rotation_distance', 0.0) / effective_gear_ratio
+            except Exception:
+                pass
+
+        return rotation_dist
+
+    def get_limiting_velocity(self, target_accel: float = 0.0) -> float | None:
+        """Return the maximum linear velocity (mm/s) before voltage saturation.
+
+        Uses the simplified linear approximation from
+        ``docs/limiting-velocity.md`` with ``I_d = 0`` and an optional
+        acceleration term:
+
+        .. math::
+
+            \\omega_{max} \\approx \\frac{\\sqrt{\\frac{V_{bus}^2}{3} -
+            (R_s I_q)^2} - \\alpha L_q I_q}{K_e}
+
+        Converts electrical rad/s to linear mm/s via pole pairs and
+        :meth:`_get_rotation_distance_mm`.
+
+        :param target_accel: electrical acceleration rad/s² (default 0 = steady state).
+        :returns: limiting velocity in mm/s, or ``None`` if insufficient data.
+        """
+        try:
+            run_i = self.current_helper.get_run_current()
+            if run_i <= 0 or self.motor_r <= 0 or self.motor_kt <= 0:
+                return None
+
+            # V_bus from TMC4671 STATUS_ADC register
+            vm = self._read_vm()
+            if vm <= 0:
+                return None
+
+            # pole_pairs from motor profile
+            pp = getattr(self, 'pole_pairs', 0)
+            if pp <= 0:
+                return None
+
+            # Simplified steady-state formula (steady-state: alpha=0)
+            # omega_max_elec ≈ √(V_bus²/3 - (R_s·I_q)²) / K_e
+            v_sq_over_3 = vm * vm / 3.0
+            r_i = self.motor_r * run_i
+            v_backemf_sq = v_sq_over_3 - r_i * r_i
+
+            if v_backemf_sq <= 0:
+                # Bus voltage too low to overcome resistive drop
+                return 0.0
+
+            # Electrical angular velocity (rad/s electric)
+            # Kt ≈ Ke in SI units (Nm/A ≡ V·s/rad)
+            omega_e = math.sqrt(v_backemf_sq) / self.motor_kt
+
+            # Apply acceleration term if non-zero target
+            if target_accel > 0 and hasattr(self, 'motor_lq'):
+                accel_term = target_accel * self.motor_lq * run_i
+                omega_e = (math.sqrt(v_backemf_sq) - accel_term) / self.motor_kt
+                if omega_e <= 0:
+                    return 0.0
+
+            # Convert to mechanical: ω_mech = ω_elec / pp
+            omega_m = omega_e / pp
+
+            # Convert to linear mm/s: v = ω_mech × (rotation_distance / 2π)
+            rot_dist = self._get_rotation_distance_mm()
+            if rot_dist <= 0:
+                return None
+
+            return omega_m * rot_dist / (2.0 * math.pi)
+
+        except Exception:
+            return None
 
     def get_status(self, eventtime=None):
         if not self.init_done:
@@ -2938,6 +2995,17 @@ class TMC4671:
                 )
             else:
                 lines.append("  Max sustainable acceleration: N/A (stepper pitch unknown)")
+
+            # Voltage-limited maximum velocity (steady-state, alpha=0)
+            lv = self.get_limiting_velocity()
+            if lv is not None:
+                lines.append(
+                    f"  Voltage-limited max velocity (steady-state): {lv:.1f} mm/s"
+                )
+            else:
+                lines.append(
+                    "  Voltage-limited max velocity: N/A (insufficient data)"
+                )
         else:
             lines.append("  Kinematics data unavailable (motor not calibrated or current zero)")
 
@@ -2955,18 +3023,9 @@ class TMC4671:
             if self.velocity_bandwidth > 0 and torq > 0:
                 tau_v = 1.0 / (2.0 * math.pi * self.velocity_bandwidth)
 
-                # Get effective pitch for linear conversion
-                pitch_m = 0.0
-                if hasattr(self, 'stepper') and self.stepper is not None:
-                    sd = getattr(self.stepper, 'rotation_distance', 0.0)
-                    if sd > 0:
-                        gr_pairs = self.printer.lookup_object('configfile').getsection(
-                            self.stepper_name).getlists(
-                            'gear_ratio', (), seps=(':', ','), count=2, parser=float)
-                        gear_ratio = 1.0
-                        for n, d in gr_pairs:
-                            gear_ratio *= n / d
-                        pitch_m = sd / (1000.0 * gear_ratio)
+                # Get effective pitch for linear conversion (de-duplicated via helper)
+                rot_dist = self._get_rotation_distance_mm()
+                pitch_m = rot_dist / (1000.0) if rot_dist > 0 else 0.0
 
                 if pitch_m > 0:
                     accel_lin_scv = torq / (self.jmotor + self.jload) * pitch_m / (2.0 * math.pi)


### PR DESCRIPTION
This PR adds helper methods for calculating:
- Available torque
- Available acceleration
- Kinematic and bandwidth-aware SCV limits

It also updates the TMC_DEBUG_TUNING report to include these values using linear units (via rotation_distance).